### PR TITLE
DEMO-2317 : validate that the aws pem key path exists only when a ec2…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      
+
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
@@ -26,18 +26,18 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-    
+
       - name: Lint
         # Remove this line to allow this job to prevent PRs from merging
         continue-on-error: true
         run: bundle exec rubocop
-  
+
   test-unit:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      
+
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
@@ -58,13 +58,13 @@ jobs:
 
       - name: Unit Tests
         run: bundle exec rake test:unit
-      
+
   test-integration:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      
+
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
@@ -82,7 +82,7 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-      
+
       - name: Generate Default SSH Keypair
         run: ssh-keygen -m PEM -t rsa -b 4096 -f $HOME/.ssh/id_rsa -q -N ""
 
@@ -93,14 +93,15 @@ jobs:
           rm -f user_acceptance_tests/uat-ca.pem
           echo "$AWS_PEM" > user_acceptance_tests/uat-ca.pem
           sudo chmod 400 user_acceptance_tests/uat-ca.pem
-      
+          sudo chmod 400 user_acceptance_tests/secret_file.pem
+
       - name: Write UAT JSON to file
         env:
           UAT_JSON: ${{ secrets.USER_UAT_JSON }}
         run: |
           echo "$UAT_JSON" > user_acceptance_tests/uatuser.json.local
 
-      - name: Integration Tests 
+      - name: Integration Tests
         run: bundle exec rake test:uat:integration
 
   test-cloudprovider-azure:
@@ -109,7 +110,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      
+
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
@@ -146,10 +147,10 @@ jobs:
 
       - name: Install Ansible Galaxy Plugins
         run: ansible-galaxy install newrelic.newrelic_java_agent
-      
+
       - name: Generate Default SSH Keypair
         run: ssh-keygen -m PEM -t rsa -b 4096 -f $HOME/.ssh/id_rsa -q -N ""
-      
+
       - name: Write AWS Certificate to File
         env:
           AWS_PEM: ${{ secrets.UAT_AWS_PEM_FILE }}
@@ -157,7 +158,7 @@ jobs:
           rm -f user_acceptance_tests/uat-ca.pem
           echo "$AWS_PEM" > user_acceptance_tests/uat-ca.pem
           sudo chmod 400 user_acceptance_tests/uat-ca.pem
-      
+
       - name: Write UAT JSON to file
         env:
           UAT_JSON: ${{ secrets.USER_UAT_JSON }}
@@ -173,7 +174,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      
+
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
@@ -212,7 +213,7 @@ jobs:
 
       - name: Generate Default SSH Keypair
         run: ssh-keygen -m PEM -t rsa -b 4096 -f $HOME/.ssh/id_rsa -q -N ""
-        
+
       - name: Write AWS Certificate to File
         env:
           AWS_PEM: ${{ secrets.UAT_AWS_PEM_FILE }}
@@ -220,16 +221,16 @@ jobs:
           rm -f user_acceptance_tests/uat-ca.pem
           echo "$AWS_PEM" > user_acceptance_tests/uat-ca.pem
           sudo chmod 400 user_acceptance_tests/uat-ca.pem
-      
+
       - name: Write UAT JSON to file
         env:
           UAT_JSON: ${{ secrets.USER_UAT_JSON }}
         run: |
           echo "$UAT_JSON" > user_acceptance_tests/aws/uat${{ github.run_id }}.json.local
-  
+
       - name: Cloud Provider Tests (AWS)
         run: bundle exec rake test:uat:aws
-  
+
   slack-notify:
     runs-on: ubuntu-latest
     needs: [lint, test-unit, test-integration, test-cloudprovider-aws, test-cloudprovider-azure]
@@ -246,7 +247,7 @@ jobs:
               username: "GitHub Actions",
               icon_emoji: ":octocat:",
               attachments: [{
-                color: ${{ 
+                color: ${{
                   needs.lint.result == 'success' &&
                   needs.test-unit.result == 'success' &&
                   needs.test-integration.result == 'success' &&
@@ -328,5 +329,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-  
-        
+

--- a/src/command_line/validator.rb
+++ b/src/command_line/validator.rb
@@ -4,17 +4,21 @@ require "./src/common/validators/validator"
 module CommandLine
   class Validator
 
-    def initialize(user_config_validator = Common::Validators::JsonFileExist.new("No user config file defined"))
+    def initialize(
+      user_config_validator = Common::Validators::JsonFileExist.new("No user config file defined"),
+      deploy_config_validator = Common::Validators::JsonFileExist.new("No deploy config file defined"))
       @user_config_validator = user_config_validator
+      @deploy_config_validator = deploy_config_validator
     end
 
     def execute(options)
       validators = [
-        lambda { return @user_config_validator.execute(options[:user_config]) }
+        lambda { return @user_config_validator.execute(options[:user_config]) },
+        lambda { return @deploy_config_validator.execute(options[:deploy_config]) }
       ]
       validator = Common::Validators::Validator.new(validators)
       return validator.execute()
     end
-    
+
   end
 end

--- a/src/command_line/validator.rb
+++ b/src/command_line/validator.rb
@@ -4,17 +4,13 @@ require "./src/common/validators/validator"
 module CommandLine
   class Validator
 
-    def initialize(
-      user_config_validator = Common::Validators::JsonFileExist.new("No user config file defined"),
-      deploy_config_validator = Common::Validators::JsonFileExist.new("No deploy config file defined"))
+    def initialize(user_config_validator = Common::Validators::JsonFileExist.new("No user config file defined"))
       @user_config_validator = user_config_validator
-      @deploy_config_validator = deploy_config_validator
     end
 
     def execute(options)
       validators = [
-        lambda { return @user_config_validator.execute(options[:user_config]) },
-        lambda { return @deploy_config_validator.execute(options[:deploy_config]) }
+        lambda { return @user_config_validator.execute(options[:user_config]) }
       ]
       validator = Common::Validators::Validator.new(validators)
       return validator.execute()

--- a/src/common/validators/field_exist_validator.rb
+++ b/src/common/validators/field_exist_validator.rb
@@ -11,7 +11,7 @@ module Common
       def execute(items)
         missing = []
         (items || []).each do |item|
-          value = item[@field_name]
+          value = item[@field_name.to_s] || item[@field_name.to_sym]
           if value.nil? || value.empty?
             missing.push(JSON.generate(item))
           end
@@ -22,7 +22,7 @@ module Common
         end
         return nil
       end
-      
+
     end
   end
 end

--- a/src/infrastructure/aws/ec2/pem_key_permission_validator.rb
+++ b/src/infrastructure/aws/ec2/pem_key_permission_validator.rb
@@ -1,0 +1,41 @@
+
+module Infrastructure
+  module Aws
+    module EC2
+      class PemKeyPermissionValidator
+        # regex to confirm the file permission is 400,500,600,700
+        # which are all valid permissions for a AWS pem key
+        PERMISSION_REGEX = /[4-7]00$/
+
+        def initialize(context)
+          @context = context
+        end
+
+        def execute()
+          pem_key_path = get_pem_key_path()
+          pem_key_persmissions = get_file_permission(pem_key_path)
+          if pem_key_persmissions.nil? || !pem_key_persmissions.to_s.match(PERMISSION_REGEX)
+            return "The pem key file '#{pem_key_path}' does not have the correct permissions.  To fix run 'chmod 400 #{pem_key_path}'."
+          end
+        end
+
+        private
+        def get_file_permission(pem_key_path)
+          begin
+            file_stats = File.stat(pem_key_path)
+          rescue
+            return nil
+          end
+          base_10_file_permission = file_stats.mode()
+          base_8_file_permission = base_10_file_permission.to_s(8)
+          return base_8_file_permission
+        end
+
+        def get_pem_key_path()
+          return @context.get_user_config_provider().get_aws_credential().get_secret_key_path()
+        end
+
+      end
+    end
+  end
+end

--- a/src/infrastructure/aws/ec2/pem_key_permission_validator.rb
+++ b/src/infrastructure/aws/ec2/pem_key_permission_validator.rb
@@ -1,7 +1,7 @@
 
 module Infrastructure
   module Aws
-    module EC2
+    module Ec2
       class PemKeyPermissionValidator
         # regex to confirm the file permission is 400,500,600,700
         # which are all valid permissions for a AWS pem key

--- a/src/infrastructure/aws/ec2/pem_key_validator.rb
+++ b/src/infrastructure/aws/ec2/pem_key_validator.rb
@@ -5,7 +5,7 @@ require "./src/infrastructure/aws/ec2/pem_key_permission_validator"
 
 module Infrastructure
   module Aws
-    module EC2
+    module Ec2
       class PemKeyValidator
 
         def initialize(context,
@@ -20,7 +20,7 @@ module Infrastructure
 
         def execute()
           validators = [
-            lambda { return get_secret_key_path_exisits_validator().execute([get_aws_credentials_as_hash()]) },
+            lambda { return get_secret_key_path_exisits_validator().execute([get_aws_credentials().to_h()]) },
             lambda { return secret_key_path_file_validator().execute(get_pem_key_path()) },
             lambda { return get_pemkey_permission_validator().execute() },
           ]
@@ -40,11 +40,11 @@ module Infrastructure
         end
 
         def get_pemkey_permission_validator()
-          return @pem_key_permission_validator ||= Infrastructure::Aws::EC2::PemKeyPermissionValidator.new(@context)
+          return @pem_key_permission_validator ||= Infrastructure::Aws::Ec2::PemKeyPermissionValidator.new(@context)
         end
 
-        def get_aws_credentials_as_hash()
-          return @context.get_user_config_provider().get_aws_credential().to_h()
+        def get_aws_credentials()
+          return @context.get_user_config_provider().get_aws_credential()
         end
 
         def get_pem_key_path()

--- a/src/infrastructure/aws/ec2/pem_key_validator.rb
+++ b/src/infrastructure/aws/ec2/pem_key_validator.rb
@@ -1,0 +1,57 @@
+
+require "./src/common/validators/validator"
+require "./src/common/validators/file_exist"
+require "./src/infrastructure/aws/ec2/pem_key_permission_validator"
+
+module Infrastructure
+  module Aws
+    module EC2
+      class PemKeyValidator
+
+        def initialize(context,
+                       secret_key_path_exisits_validator = nil,
+                       secret_key_path_file_validator = nil,
+                       pem_key_permission_validator = nil)
+          @context = context
+          @secret_key_path_exisits_validator = secret_key_path_exisits_validator
+          @secret_key_path_file_validator = secret_key_path_file_validator
+          @pem_key_permission_validator = pem_key_permission_validator
+        end
+
+        def execute()
+          validators = [
+            lambda { return get_secret_key_path_exisits_validator().execute([get_aws_credentials_as_hash()]) },
+            lambda { return secret_key_path_file_validator().execute(get_pem_key_path()) },
+            lambda { return get_pemkey_permission_validator().execute() },
+          ]
+          validator = Common::Validators::Validator.new(validators)
+          return validator.execute()
+        end
+
+        private
+
+        def get_secret_key_path_exisits_validator()
+          return @secret_key_path_exisits_validator ||= Common::Validators::FieldExistValidator.new("secret_key_path", "secret_key_path is missing for aws credential:")
+        end
+
+
+        def secret_key_path_file_validator()
+          return @secret_key_path_file_validator ||= Common::Validators::FileExist.new("A valid secret file could not be found in the path defined")
+        end
+
+        def get_pemkey_permission_validator()
+          return @pem_key_permission_validator ||= Infrastructure::Aws::EC2::PemKeyPermissionValidator.new(@context)
+        end
+
+        def get_aws_credentials_as_hash()
+          return @context.get_user_config_provider().get_aws_credential().to_h()
+        end
+
+        def get_pem_key_path()
+          return @context.get_user_config_provider().get_aws_credential().get_secret_key_path()
+        end
+
+      end
+    end
+  end
+end

--- a/src/infrastructure/aws/ec2/validator.rb
+++ b/src/infrastructure/aws/ec2/validator.rb
@@ -28,7 +28,7 @@ module Infrastructure
         end
 
         def get_pemkey_validator()
-          return @pem_key_validator ||= Infrastructure::Aws::EC2::PemKeyValidator.new(@context)
+          return @pem_key_validator ||= Infrastructure::Aws::Ec2::PemKeyValidator.new(@context)
         end
 
         def get_supported_sizes()

--- a/src/infrastructure/aws/ec2/validator.rb
+++ b/src/infrastructure/aws/ec2/validator.rb
@@ -1,18 +1,22 @@
+require "./src/common/validators/validator"
 require "./src/common/validators/size_validator"
+require "./src/infrastructure/aws/ec2/pem_key_validator"
 
 module Infrastructure
   module Aws
     module Ec2
       class Validator
 
-        def initialize(sizes_supported, size_validator = nil)
-          @sizes_supported = sizes_supported
+        def initialize(context, size_validator = nil, pem_key_validator = nil)
+          @context = context
           @size_validator = size_validator
+          @pem_key_validator = pem_key_validator
         end
 
         def execute(resources)
           validators = [
-            lambda { return get_size_validator().execute(resources) }
+            lambda { return get_size_validator().execute(resources) },
+            lambda { return get_pemkey_validator().execute() }
           ]
           validator = Common::Validators::Validator.new(validators)
           return validator.execute()
@@ -20,7 +24,15 @@ module Infrastructure
 
         private
         def get_size_validator()
-          return @size_validator ||= Common::Validators::SizeValidator.new(@sizes_supported)
+          return @size_validator ||= Common::Validators::SizeValidator.new(get_supported_sizes())
+        end
+
+        def get_pemkey_validator()
+          return @pem_key_validator ||= Infrastructure::Aws::EC2::PemKeyValidator.new(@context)
+        end
+
+        def get_supported_sizes()
+          return @context.get_app_config_provider().get_aws_ec2_supported_sizes()
         end
 
       end

--- a/src/infrastructure/aws/type_validator_factory.rb
+++ b/src/infrastructure/aws/type_validator_factory.rb
@@ -8,11 +8,11 @@ module Infrastructure
   module Aws
     class TypeValidatorFactory < Common::Validators::ValidatorFactory
 
-      def initialize(app_config_provider)
-        @app_config_provider = app_config_provider
+      def initialize(context)
+        @context = context
         super(
           {
-            "ec2" => Ec2::Validator.new(get_supported_sizes()),
+            "ec2" => Ec2::Validator.new(@context),
             "elb" => Elb::Validator.new(get_aws_elb_max_listeners()),
             "lambda" => Lambda::Validator.new(),
             "r53ip" => R53Ip::Validator.new()
@@ -23,12 +23,9 @@ module Infrastructure
       end
 
       private
-      def get_supported_sizes()
-        return @app_config_provider.get_aws_ec2_supported_sizes()
-      end
 
       def get_aws_elb_max_listeners()
-        return @app_config_provider.get_aws_elb_max_listeners()
+        return @context.get_app_config_provider().get_aws_elb_max_listeners()
       end
 
     end

--- a/src/infrastructure/aws/validator.rb
+++ b/src/infrastructure/aws/validator.rb
@@ -4,8 +4,8 @@ module Infrastructure
   module Aws
     class Validator
 
-      def initialize(app_config_provider, type_validator_factory = nil)
-        @app_config_provider = app_config_provider
+      def initialize(context, type_validator_factory = nil)
+        @context = context
         @type_validator_factory = type_validator_factory
       end
 
@@ -25,7 +25,7 @@ module Infrastructure
       end
 
       def get_type_validator_factory()
-        return @type_validator_factory ||= TypeValidatorFactory.new(@app_config_provider)
+        return @type_validator_factory ||= TypeValidatorFactory.new(@context)
       end
 
     end

--- a/src/infrastructure/orchestrator.rb
+++ b/src/infrastructure/orchestrator.rb
@@ -38,8 +38,7 @@ module Infrastructure
 
     private
     def get_validator()
-      app_config_provider = @context.get_app_config_provider()
-     return @validator ||= Infrastructure::Validator.new(app_config_provider)
+     return @validator ||= Infrastructure::Validator.new(@context)
     end
 
   end

--- a/src/infrastructure/provider_validator_factory.rb
+++ b/src/infrastructure/provider_validator_factory.rb
@@ -8,10 +8,12 @@ module Infrastructure
     def initialize(app_config_provider)
       @app_config_provider = app_config_provider
       super(
-        { "aws" => Aws::Validator,
-          "azure" => Azure::Validator },
-        lambda {|resource| return resource['provider']},
-        lambda {|validator_type| return validator_type.new(@app_config_provider)}
+        {
+          "aws" => Aws::Validator,
+          "azure" => Azure::Validator
+        },
+        lambda { |resource| return resource['provider'] },
+        lambda { |validator_type| return validator_type.new(@app_config_provider) }
       )
     end
 

--- a/src/infrastructure/provider_validator_factory.rb
+++ b/src/infrastructure/provider_validator_factory.rb
@@ -5,15 +5,15 @@ require_relative "azure/validator"
 module Infrastructure
   class ProviderValidatorFactory < Common::Validators::ValidatorFactory
 
-    def initialize(app_config_provider)
-      @app_config_provider = app_config_provider
+    def initialize(context)
+      @context = context
       super(
         {
           "aws" => Aws::Validator,
           "azure" => Azure::Validator
         },
         lambda { |resource| return resource['provider'] },
-        lambda { |validator_type| return validator_type.new(@app_config_provider) }
+        lambda { |validator_type| return validator_type.new(@context) }
       )
     end
 

--- a/src/infrastructure/validator.rb
+++ b/src/infrastructure/validator.rb
@@ -9,13 +9,13 @@ module Infrastructure
   class Validator
 
     def initialize(
-        app_config_provider,
+        context,
         resource_id_validator = Common::Validators::FieldExistValidator.new("id", "Resource id is missing:"),
         unique_id_validator = Common::Validators::UniqueIdValidator.new("id", "Duplicate resource_id found:"),
         provider_validator_factory = nil,
         id_alphanumeric_validator = Common::Validators::AlphaNumericListValidator.new("id", "Resource id syntax error:")
         )
-      @app_config_provider = app_config_provider
+      @context = context
       @resource_id_validator = resource_id_validator
       @unique_id_validator = unique_id_validator
       @provider_validator_factory = provider_validator_factory
@@ -43,12 +43,17 @@ module Infrastructure
     end
 
     def get_resource_id_length_validator()
-      id_max_length = @app_config_provider.get_resource_id_max_length()
+      id_max_length = get_resource_id_max_length()
       return @resource_id_length_validator ||= Common::Validators::MaxLengthValidator.new("id", id_max_length, "Resource id should be #{id_max_length} characters at most")
     end
 
     def get_provider_validator_factory()
-      return @provider_validator_factory ||= ProviderValidatorFactory.new(@app_config_provider)
+      return @provider_validator_factory ||= ProviderValidatorFactory.new(@context)
+    end
+
+    def get_resource_id_max_length()
+      app_config_provider = @context.get_app_config_provider()
+      return app_config_provider.get_resource_id_max_length()
     end
 
   end

--- a/src/user_config/definitions/aws_credential.rb
+++ b/src/user_config/definitions/aws_credential.rb
@@ -18,7 +18,7 @@ module UserConfig
 
       def get_secret_key_name()
         secrect_key_path = get_secret_key_path()
-        if secrect_key_path.nil? == false
+        unless secrect_key_path.nil?
           return File.basename(secrect_key_path, ".*")
         end
         return nil

--- a/src/user_config/definitions/aws_credential.rb
+++ b/src/user_config/definitions/aws_credential.rb
@@ -17,17 +17,21 @@ module UserConfig
       end
 
       def get_secret_key_name()
-        return File.basename(get_secret_key_path(), ".*")
+        secrect_key_path = get_secret_key_path()
+        if secrect_key_path.nil? == false
+          return File.basename(secrect_key_path, ".*")
+        end
+        return nil
       end
 
       def get_secret_key_path()
         return @user_config_query_lambda.call("secretKeyPath")
-      end        
+      end
 
       def get_region()
         return @user_config_query_lambda.call("region")
       end
-      
+
       def to_h()
         return {
           "api_key": get_api_key(),

--- a/src/user_config/validators/aws_validator.rb
+++ b/src/user_config/validators/aws_validator.rb
@@ -6,16 +6,12 @@ module UserConfig
     class AwsValidator
 
       def initialize(
-          secret_file_validator = nil,
           api_key_validator = nil,
           secret_key_validator = nil,
-          secret_key_path_validator = nil,
           region_validator = nil
         )
-        @secret_file_validator = secret_file_validator || Common::Validators::FileExist.new("A valid secret file could not be found in the path defined")
         @api_key_validator = api_key_validator || Common::Validators::FieldExistValidator.new("apiKey", "apiKey is missing for aws credential:")
         @secret_key_validator = secret_key_validator || Common::Validators::FieldExistValidator.new("secretKey", "secretKey is missing for aws credential:")
-        @secret_key_path_validator = secret_key_path_validator || Common::Validators::FieldExistValidator.new("secretKeyPath", "secretKeyPath is missing for aws credential:")
         @region_validator = region_validator || Common::Validators::FieldExistValidator.new("region", "region is missing for aws credential:")
       end
 
@@ -23,13 +19,8 @@ module UserConfig
         validators = [
           lambda { return @api_key_validator.execute(aws_configs) },
           lambda { return @secret_key_validator.execute(aws_configs) },
-          lambda { return @secret_key_path_validator.execute(aws_configs) },
           lambda { return @region_validator.execute(aws_configs) }
         ]
-
-        aws_configs.each do |aws_config|
-          validators.push(lambda { return @secret_file_validator.execute(aws_config["secretKeyPath"]) } )
-        end
 
         validator = Common::Validators::Validator.new(validators)
         return validator.execute()

--- a/tests/common/validators/field_exist_validator_tests.rb
+++ b/tests/common/validators/field_exist_validator_tests.rb
@@ -8,35 +8,55 @@ describe "Common" do
   describe "Validators" do
     describe "FieldExistValidator" do
       let(:items) { [] }
-      let(:validator) { Common::Validators::FieldExistValidator.new("id")}
-      
+      let(:validator_string) { Common::Validators::FieldExistValidator.new("id")}
+      let(:validator_symbol) { Common::Validators::FieldExistValidator.new(:id)}
+
       it "should create validator" do
-        validator.wont_be_nil
+        _(validator_string).wont_be_nil
       end
 
-      it "should allow item with id" do
-          given_item("host1", "gws")
-          validator.execute(items).must_be_nil()
-      end    
-      
-      it "should not allow item with nil id" do
-        given_item(nil, "gws")
-        validator.execute(items).wont_be_nil()
-        validator.execute(items).must_include("gws")
+      it "should allow string item with string id" do
+        given_item_string("host1", "gws")
+        _(validator_string.execute(items)).must_be_nil()
+      end
+
+      it "should allow string item with symbol id" do
+        given_item_string("host1", "gws")
+        _(validator_symbol.execute(items)).must_be_nil()
+      end
+
+      it "should allow symbol item with string id" do
+        given_item_symbol("host1", "gws")
+        _(validator_string.execute(items)).must_be_nil()
+      end
+
+      it "should allow symbol item with symbol id" do
+        given_item_symbol("host1", "gws")
+        _(validator_symbol.execute(items)).must_be_nil()
+      end
+
+      it "should not allow string item with nil id" do
+        given_item_string(nil, "gws")
+        _(validator_string.execute(items)).wont_be_nil()
+        _(validator_string.execute(items)).must_include("gws")
       end
 
       it "should not allow item without id" do
         given_item_without_id("gws")
-        validator.execute(items).wont_be_nil()
-        validator.execute(items).must_include("gws")
+        _(validator_string.execute(items)).wont_be_nil()
+        _(validator_string.execute(items)).must_include("gws")
       end
 
       def given_item_without_id(provider = nil)
         items.push({"provider" => provider})
       end
 
-      def given_item(id, provider = nil)
+      def given_item_string(id, provider = nil)
         items.push({"id"=> id, "provider" => provider})
+      end
+
+      def given_item_symbol(id, provider = nil)
+        items.push({:id=> id, :provider => provider})
       end
 
     end

--- a/tests/context_builder.rb
+++ b/tests/context_builder.rb
@@ -20,7 +20,7 @@ module Tests
       @infrastructure_provider_builder = Tests::Infrastructure::InfrastructureProviderBuilder.new(self)
       @services_provider_builder = Tests::Services::ServicesProviderBuilder.new(self)
       @instrumentation_provider_builder = Tests::Instrumentation::InstrumentationProviderBuilder.new(self)
-      @provision_provider_builder = Tests::Provision::ProvisionProviderBuilder.new(self)      
+      @provision_provider_builder = Tests::Provision::ProvisionProviderBuilder.new(self)
       # Defaulting
       @command_line_provider_builder.user_config("user.json")
       @command_line_provider_builder.deploy_config("deploy.json")
@@ -29,7 +29,7 @@ module Tests
     def command_line()
       return @command_line_provider_builder
     end
-    
+
     def app_config()
       return @app_config_provider_builder
     end
@@ -37,7 +37,7 @@ module Tests
     def user_config()
       return @user_config_provider_builder
     end
-    
+
     def tags()
       return @tags_provider_builder
     end
@@ -45,7 +45,7 @@ module Tests
     def infrastructure()
       return @infrastructure_provider_builder
     end
-    
+
     def services()
       return @services_provider_builder
     end

--- a/tests/infrastructure/aws/ec2/pem_key_permission_validator_tests.rb
+++ b/tests/infrastructure/aws/ec2/pem_key_permission_validator_tests.rb
@@ -10,7 +10,7 @@ describe "Infrastructure::Aws::Ec2::PemKeyPermissionValidator" do
     .user_config().with_aws()
     .build() }
   let(:pem_key_path) { "/pem/key/path/pem.pem" }
-  let(:validator) { Infrastructure::Aws::EC2::PemKeyPermissionValidator.new(context) }
+  let(:validator) { Infrastructure::Aws::Ec2::PemKeyPermissionValidator.new(context) }
 
   let(:valid_pem_base_8_permission)   { "100400".to_i(8) }
   let(:invalid_pem_base_8_permission) { "100401".to_i(8) }

--- a/tests/infrastructure/aws/ec2/pem_key_permission_validator_tests.rb
+++ b/tests/infrastructure/aws/ec2/pem_key_permission_validator_tests.rb
@@ -1,0 +1,40 @@
+require "minitest/spec"
+require "minitest/autorun"
+require "mocha/minitest"
+require "./tests/context_builder.rb"
+
+require "./src/infrastructure/aws/ec2/pem_key_permission_validator"
+
+describe "Infrastructure::Aws::Ec2::PemKeyPermissionValidator" do
+  let(:context){ Tests::ContextBuilder.new()
+    .user_config().with_aws()
+    .build() }
+  let(:pem_key_path) { "/pem/key/path/pem.pem" }
+  let(:validator) { Infrastructure::Aws::EC2::PemKeyPermissionValidator.new(context) }
+
+  let(:valid_pem_base_8_permission)   { "100400".to_i(8) }
+  let(:invalid_pem_base_8_permission) { "100401".to_i(8) }
+
+  it "should create validator" do
+    _(validator).wont_be_nil()
+  end
+
+  it "should find pem key permission valid" do
+    @mock_file = Minitest::Mock.new
+    @mock_file.expect(:mode, valid_pem_base_8_permission)
+
+    File.stub :stat, @mock_file do
+      _(validator.execute()).must_be_nil
+    end
+  end
+
+  it "should find pem key permission invalid" do
+    @mock_file = Minitest::Mock.new
+    @mock_file.expect(:mode, invalid_pem_base_8_permission)
+
+    File.stub :stat, @mock_file do
+      _(validator.execute()).wont_be_nil
+    end
+  end
+
+end

--- a/tests/infrastructure/aws/ec2/pem_key_validator_tests.rb
+++ b/tests/infrastructure/aws/ec2/pem_key_validator_tests.rb
@@ -14,7 +14,7 @@ describe "Infrastructure::Aws::Ec2::PemKeyValidator" do
   let(:secret_key_path_file_validator) { m = mock(); m.stubs(:execute); m }
   let(:pem_key_permission_validator) { m = mock(); m.stubs(:execute); m }
 
-  let(:validator) { Infrastructure::Aws::EC2::PemKeyValidator.new(context,secret_key_path_exisits_validator,secret_key_path_file_validator,pem_key_permission_validator) }
+  let(:validator) { Infrastructure::Aws::Ec2::PemKeyValidator.new(context,secret_key_path_exisits_validator,secret_key_path_file_validator,pem_key_permission_validator) }
 
   it "should create validator" do
     _(validator).wont_be_nil()

--- a/tests/infrastructure/aws/ec2/pem_key_validator_tests.rb
+++ b/tests/infrastructure/aws/ec2/pem_key_validator_tests.rb
@@ -1,0 +1,38 @@
+require "minitest/spec"
+require "minitest/autorun"
+require "mocha/minitest"
+require "./tests/context_builder.rb"
+
+require "./src/infrastructure/aws/ec2/pem_key_validator"
+
+describe "Infrastructure::Aws::Ec2::PemKeyValidator" do
+  let(:pem_key_path) { "/pem/key/path/pem.pem" }
+  let(:context){ Tests::ContextBuilder.new()
+    .user_config().with_aws()
+    .build() }
+  let(:secret_key_path_exisits_validator) { m = mock(); m.stubs(:execute); m }
+  let(:secret_key_path_file_validator) { m = mock(); m.stubs(:execute); m }
+  let(:pem_key_permission_validator) { m = mock(); m.stubs(:execute); m }
+
+  let(:validator) { Infrastructure::Aws::EC2::PemKeyValidator.new(context,secret_key_path_exisits_validator,secret_key_path_file_validator,pem_key_permission_validator) }
+
+  it "should create validator" do
+    _(validator).wont_be_nil()
+  end
+
+  it "should invoke key path exists validator" do
+    secret_key_path_exisits_validator.expects(:execute)
+    validator.execute()
+  end
+
+  it "should invoke key path file validator" do
+    secret_key_path_file_validator.expects(:execute)
+    validator.execute()
+  end
+
+  it "should invoke key permission validator" do
+    pem_key_permission_validator.expects(:execute)
+    validator.execute()
+  end
+
+end

--- a/tests/infrastructure/aws/ec2/validator_tests.rb
+++ b/tests/infrastructure/aws/ec2/validator_tests.rb
@@ -1,14 +1,18 @@
 require "minitest/spec"
 require "minitest/autorun"
 require "mocha/minitest"
+require "./tests/context_builder.rb"
 
 require "./src/infrastructure/aws/ec2/validator"
 
 describe "Infrastructure::Aws::Ec2::Validator" do
+  let(:context){ Tests::ContextBuilder.new()
+    .user_config().with_aws()
+    .build() }
   let(:resources) { [] }
   let(:size_validator) { m = mock(); m.stubs(:execute); m }
-  let(:aws_sizes_supported) { [] }
-  let(:validator) { Infrastructure::Aws::Ec2::Validator.new(aws_sizes_supported, size_validator) }
+  let(:pem_key_validator) { m = mock(); m.stubs(:execute); m }
+  let(:validator) { Infrastructure::Aws::Ec2::Validator.new(context, size_validator, pem_key_validator) }
 
   it "should create validator" do
     validator.wont_be_nil
@@ -18,4 +22,10 @@ describe "Infrastructure::Aws::Ec2::Validator" do
     size_validator.expects(:execute)
     validator.execute(resources)
   end
+
+  it "should invoke pem key validator factory" do
+    pem_key_validator.expects(:execute)
+    validator.execute(resources)
+  end
+
 end

--- a/tests/infrastructure/aws/type_validator_factory_tests.rb
+++ b/tests/infrastructure/aws/type_validator_factory_tests.rb
@@ -1,19 +1,19 @@
 require "minitest/spec"
 require "minitest/autorun"
 require "mocha/minitest"
+require "./tests/context_builder.rb"
 
 require "./src/infrastructure/aws/type_validator_factory"
 
 describe "Infrastructure::Aws::TypeValidatorFactory" do
   let(:resources) { [] }
   let(:supported_types) { {} }
-  let(:app_config_provider) {
-    m = mock();
-    m.stubs(:get_aws_ec2_supported_sizes).returns([]);
-    m.stubs(:get_aws_elb_max_listeners).returns(3);
-    m  }
-  let(:factory) { Infrastructure::Aws::TypeValidatorFactory.new(app_config_provider) }
-  
+  let(:context){ Tests::ContextBuilder.new()
+    .user_config().with_aws()
+    .build() }
+
+  let(:factory) { Infrastructure::Aws::TypeValidatorFactory.new(context) }
+
   it "should create validator" do
     factory.wont_be_nil
   end

--- a/tests/infrastructure/validator_tests.rb
+++ b/tests/infrastructure/validator_tests.rb
@@ -2,27 +2,26 @@ require "minitest/spec"
 require "minitest/autorun"
 require "mocha/minitest"
 require "json"
-
-require "./src/infrastructure/validator"
+require "./tests/context_builder.rb"
 require "./tests/orchestrator_tests"
 
-describe "Infrastructure::Validator::execute" do
+require "./src/infrastructure/validator"
+
+describe "Infrastructure::Validator" do
   let(:resources) { [] }
   let(:resource_id_validator) { m = mock(); m.stubs(:execute); m }
   let(:unique_id_validator) { m = mock(); m.stubs(:execute); m }
   let(:id_alphanumeric_validator) { m = mock(); m.stubs(:execute); m }
-  let(:app_config_provider) {
-    m = mock();
-    m.stubs(:get_aws_ec2_supported_sizes).returns([]);
-    m.stubs(:get_aws_elb_max_listeners).returns(3);
-    m.stubs(:get_resource_id_max_length).returns(10);
-    m  }
+  let(:context){ Tests::ContextBuilder.new()
+    .user_config().with_aws()
+    .build() }
+
   let(:provider_validator_factory) { m = mock(); m.stubs(:create_validators).returns([]); m }
   let(:id_max_length) { 10 }
   let(:resource_id_length_validation) { Common::Validators::MaxLengthValidator.new("id", id_max_length, "Error") }
 
   let(:validator) { Infrastructure::Validator.new(
-    app_config_provider,
+    context,
     resource_id_validator,
     unique_id_validator,
     provider_validator_factory,

--- a/tests/user_config/validators/aws_validator_tests.rb
+++ b/tests/user_config/validators/aws_validator_tests.rb
@@ -6,16 +6,12 @@ require "./src/user_config/validators/aws_validator"
 
 describe "UserConfig::Validators::AwsValidator" do
   let(:aws_configs) { [] }
-  let(:secret_file_validator) { m = mock(); m.stubs(:execute); m }
   let(:api_key_validator) { m = mock(); m.stubs(:execute); m }
   let(:secret_key_validator) { m = mock(); m.stubs(:execute); m }
-  let(:secret_key_path_validator) { m = mock(); m.stubs(:execute); m }
   let(:region_validator) { m = mock(); m.stubs(:execute); m }
   let(:validator) { UserConfig::Validators::AwsValidator.new(
-    secret_file_validator,
     api_key_validator,
     secret_key_validator,
-    secret_key_path_validator,
     region_validator
     ) }
 
@@ -23,12 +19,6 @@ describe "UserConfig::Validators::AwsValidator" do
     validator.wont_be_nil
   end
 
-  it "should execute secret_file_validator" do
-    given_aws_credential()
-    secret_file_validator.expects(:execute)
-    validator.execute(aws_configs)
-  end
-  
   it "should execute api_key_validator" do
     given_aws_credential("my api key", "my secret key", "my secret key path", "my region")
     api_key_validator.expects(:execute)
@@ -38,12 +28,6 @@ describe "UserConfig::Validators::AwsValidator" do
   it "should execute secret_key_validator" do
     given_aws_credential("my api key", "my secret key", "my secret key path", "my region")
     secret_key_validator.expects(:execute)
-    validator.execute(aws_configs)
-  end
-
-  it "should execute secret_key_path_validator" do
-    given_aws_credential("my api key", "my secret key", "my secret key path", "my region")
-    secret_key_path_validator.expects(:execute)
     validator.execute(aws_configs)
   end
 

--- a/user_acceptance_tests/integration/configuration/deployment_validation_tests.rb
+++ b/user_acceptance_tests/integration/configuration/deployment_validation_tests.rb
@@ -78,7 +78,7 @@ describe "UserAcceptanceTests::Deployment" do
       given_user_config(credentials)
       given_deploy_config(resources, services)
       error = assert_raises Common::ValidationError do
-        mock_pem_key_permissions() do
+        mock_valid_pem_key_file_permission() do
           orchestrator.execute(arguments)
         end
       end
@@ -101,7 +101,7 @@ describe "UserAcceptanceTests::Deployment" do
       given_user_config(credentials)
       given_deploy_config(resources, services)
       error = assert_raises Common::ValidationError do
-        mock_pem_key_permissions() do
+        mock_valid_pem_key_file_permission() do
           orchestrator.execute(arguments)
         end
       end
@@ -115,7 +115,7 @@ describe "UserAcceptanceTests::Deployment" do
       given_service("app2", 1443, ["host1"], "this is not a directory path")
       given_deploy_config(resources, services)
       error = assert_raises Common::ValidationError do
-        mock_pem_key_permissions() do
+        mock_valid_pem_key_file_permission() do
           orchestrator.execute(arguments)
         end
       end
@@ -194,10 +194,10 @@ describe "UserAcceptanceTests::Deployment" do
       user_config_jsonfilebuilder.build()
     end
 
-    def mock_pem_key_permissions()
-        @mock_file = Minitest::Mock.new
-        @mock_file.expect(:mode, "100400".to_i(8))
-        File.stub :stat, @mock_file do
+    def mock_valid_pem_key_file_permission()
+        @mock_pem_file = Minitest::Mock.new
+        @mock_pem_file.expect(:mode, "100400".to_i(8))
+        File.stub :stat, @mock_pem_file do
           yield
         end
     end

--- a/user_acceptance_tests/integration/configuration/user_config_validation_tests.rb
+++ b/user_acceptance_tests/integration/configuration/user_config_validation_tests.rb
@@ -54,7 +54,7 @@ describe "UserAcceptanceTests::UserConfig" do
       given_deploy_config(resources, services)
       error = assert_raises Common::ValidationError do
         orchestrator.execute(arguments)
-      end        
+      end
       error.message.must_include("Configuration file is missing credentials section")
     end
 
@@ -64,17 +64,17 @@ describe "UserAcceptanceTests::UserConfig" do
       given_deploy_config(resources, services)
       error = assert_raises Common::ValidationError do
         orchestrator.execute(arguments)
-      end        
+      end
       error.message.must_include("apiKey")
     end
-    
+
     it "should fail on missing secret key" do
       given_credential("aws", api_key, nil, secret_key_path, region)
       given_user_config(credentials)
       given_deploy_config(resources, services)
       error = assert_raises Common::ValidationError do
         orchestrator.execute(arguments)
-      end        
+      end
       error.message.must_include("secretKey")
     end
 
@@ -84,22 +84,22 @@ describe "UserAcceptanceTests::UserConfig" do
       given_deploy_config(resources, services)
       error = assert_raises Common::ValidationError do
         orchestrator.execute(arguments)
-      end        
-      error.message.must_include("secretKeyPath")
+      end
+      error.message.must_include("secret_key_path")
     end
-    
+
     it "should fail on missing region" do
       given_credential("aws", api_key, secret_key, secret_key_path, nil)
       given_user_config(credentials)
       given_deploy_config(resources, services)
       error = assert_raises Common::ValidationError do
         orchestrator.execute(arguments)
-      end        
+      end
       error.message.must_include("region")
     end
-    
+
   end
-  
+
   def create_resource(id, provider = nil, type = nil, size = nil)
     resource = {id: id}
     unless provider.nil?
@@ -151,13 +151,13 @@ describe "UserAcceptanceTests::UserConfig" do
     user_config_jsonfilebuilder.with("credentials", credentials)
     user_config_jsonfilebuilder.build()
   end
-  
+
   def given_user_config_with_no_credentials()
     arguments.push("-c")
     arguments.push(user_config_filename)
     user_config_jsonfilebuilder.build()
   end
-  
+
   def given_deploy_config(resources = [], services = [])
     arguments.push("-d")
     arguments.push(deploy_config_filename)


### PR DESCRIPTION
This PR changes how the Deployer validates the AWS pem key.  Before this PR the user config validator would ensure the PEM key path existed.  The responsibility for validation have been moved to the AWS EC2 validator.  In addition we now check that the pem key file has the correct permissions.