### PR TITLE
Adding ability to define ami_name in deploy config for AWS/EC2 resources

### DIFF
--- a/documentation/deploy_config/resources/aws/ec2/README.md
+++ b/documentation/deploy_config/resources/aws/ec2/README.md
@@ -30,6 +30,17 @@ Once deployed, you can find that resource on AWS Console, EC2 dashboard.
 The deployer follows a naming convention when creating resources. All resources have the following format `[user config filename prefix]-[deploy config filename prefix]-[resource_id]`
 For example, if you've run the deployer with a command `ruby main.rb -c jsmith.local.json -d hello.json` with `hello.json` the resource definition above, you'll find an EC2 resource created with a name of `jsmith-hello-host1`.
 
+### ami_name
+
+Optional, this field specify which ami to use. The default ami name is `amzn2-ami-hvm-2.0.20190228-x86_64-gp2`.
+The value is used as a filter pattern to find the most recent AMI of a resultset.
+For example `"ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????.1"` will search and find the most recent Ubuntu 18.04 version.
+Note, when using an OS having a different user than the default `ec2-user` name, the field `user_name` should be used to configure which user name to use for SSH.
+
+### user_name
+
+Optional, this field specify which user to use for SSH. By default the value of `ec2-user` is used, which is the default user for AWS Linux AMIs. For example, a `user_name` of `ubuntu` should be used when provisioning a Ubuntu linux instance.
+
 ### size
 
 This field specify which size to use for the EC2 instance. All the possible values are configured in the [`/src/config/app_config.yml`](/src/config/app_config.yml) for the element `awsEc2SupportedSizes`.

--- a/src/app_config/provider.rb
+++ b/src/app_config/provider.rb
@@ -8,6 +8,11 @@ module AppConfig
       @config_file = config_file || {}
     end
 
+    def get_deployer_version()
+      version = "#{@config_file["deployerMajorVersion"]}.#{@config_file["deployerMinorVersion"]}.#{@config_file["deployerBuildVersion"]}"
+      return version
+    end
+
     def get_execution_path()
       output_path = @config_file["executionPath"]
       return output_path

--- a/src/config/app_config.yml
+++ b/src/config/app_config.yml
@@ -1,4 +1,8 @@
 ---
+deployerMajorVersion: "3"
+deployerMinorVersion: "0"
+deployerBuildVersion: "0"
+
 #executionPath is where the files associated with your deploy will get created 
 #and where you will find your deployment summary file.
 executionPath: "/tmp"

--- a/src/infrastructure/definitions/aws/ec2_resource.rb
+++ b/src/infrastructure/definitions/aws/ec2_resource.rb
@@ -26,6 +26,9 @@ module Infrastructure
         def get_ami_name()
           return @ami_name
         end
+        def set_ami_name(ami_name)
+          @ami_name = ami_name
+        end
 
         def get_tags()
           return @tags.merge({})

--- a/src/infrastructure/definitions/aws/resource_factory.rb
+++ b/src/infrastructure/definitions/aws/resource_factory.rb
@@ -23,7 +23,12 @@ module Infrastructure
 
           case config_resource["type"]
             when "ec2"
-              return Ec2Resource.new(resource_id, credential, config_resource["size"], user_name, tags, config_resource["cpu_credit_specification"])
+              ec2_resource = Ec2Resource.new(resource_id, credential, config_resource["size"], user_name, tags, config_resource["cpu_credit_specification"])
+              ami_name = config_resource["ami_name"]
+              unless ami_name.empty?
+                ec2_resource.set_ami_name(ami_name)
+              end
+              return ec2_resource
 
             when "elb"
               return ElbResource.new(resource_id, credential, config_resource["listeners"], user_name, tags)

--- a/src/infrastructure/definitions/aws/resource_factory.rb
+++ b/src/infrastructure/definitions/aws/resource_factory.rb
@@ -25,7 +25,7 @@ module Infrastructure
             when "ec2"
               ec2_resource = Ec2Resource.new(resource_id, credential, config_resource["size"], user_name, tags, config_resource["cpu_credit_specification"])
               ami_name = config_resource["ami_name"]
-              unless ami_name.empty?
+              unless (ami_name.nil? || ami_name.empty?)
                 ec2_resource.set_ami_name(ami_name)
               end
               return ec2_resource

--- a/src/provision/templates/aws/ec2/template.erb
+++ b/src/provision/templates/aws/ec2/template.erb
@@ -33,10 +33,16 @@
         msg: "AMI not found"
       when: found_ec2_ami_fact is not defined
 
-    - name: set AMI ID fact
+    - name:  set AMI ID fact
+      vars:
+        amis: >
+          {{ found_ec2_ami_fact.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}
       set_fact:
-        ami_id:  "{{item['image_id']}}"
-      with_items: "{{found_ec2_ami_fact['images']}}"
+        ami_id:  "{{ amis.image_id }}"
+
+    - name: Found ami output
+      debug:
+        msg: "Using ami_id:{{ami_id}}"
 
     - name: Security group rule descriptions - "{{ resource_id }}"
       ec2_group:

--- a/src/tags/provider.rb
+++ b/src/tags/provider.rb
@@ -37,10 +37,11 @@ module Tags
 
     private
     def get_deployment_tags()
+      deployer_version = @context.get_app_config_provider().get_deployer_version()
       tags = { 
         "dxDeploymentName" => "[global:deployment_name]",
         "dxDeploymentDate" => Date.today.to_s,
-        "dxDeployerVersion" => "3.0.0",
+        "dxDeployerVersion" => deployer_version,
         "dxDeployedBy" => "[global:user_name]"
       }
       return tags

--- a/tests/app_config/provider_tests.rb
+++ b/tests/app_config/provider_tests.rb
@@ -5,7 +5,18 @@ require "mocha/minitest"
 require "./src/app_config/provider"
 
 describe "AppConfig::Provider" do
-  let(:app_config) {{"executionPath"=>"path", "summaryFilename"=>"filename.txt", "serviceIdMaxLength"=>99, "resourceIdMaxLength"=>99, "awsEc2SupportedSizes"=>["t2.nino", "t2.micra", "t2.smallz", "t2.mediums"], "awsElbPort"=>45, "awsElbMaxListeners"=>99}}
+  let(:app_config) {{
+      "deployerMajorVersion"=>"a",
+      "deployerMinorVersion"=>"b",
+      "deployerBuildVersion"=>"c",
+      "executionPath"=>"path", 
+      "summaryFilename"=>"filename.txt", 
+      "serviceIdMaxLength"=>99, 
+      "resourceIdMaxLength"=>99, 
+      "awsEc2SupportedSizes"=>["t2.nino", "t2.micra", "t2.smallz", "t2.mediums"], 
+      "awsElbPort"=>45, 
+      "awsElbMaxListeners"=>99
+    }}
   let(:provider) { AppConfig::Provider.new(app_config)}
 
   it "should create provider" do
@@ -52,6 +63,10 @@ describe "AppConfig::Provider" do
     it "should get max number of listeners associated with an ELB if it exists" do
       provider.get_aws_elb_max_listeners().must_equal(99)
     end
+  end
+
+  it "Should get deployer version" do
+    provider.get_deployer_version().must_equal("a.b.c")
   end
 
 end


### PR DESCRIPTION
I've also added the definition of the deployer version in the app config.