### PR TITLE
Swap CMD for ENTRYPOINT in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,4 @@ RUN bundle install --clean --force
 # CMD [ "python", "--version"]
 # CMD [ "rake"]
 
-CMD [ "ruby", "main.rb"]
+ENTRYPOINT [ "ruby", "main.rb" ]

--- a/src/app_config.yml
+++ b/src/app_config.yml
@@ -1,7 +1,7 @@
 ---
 deployerMajorVersion: "3"
-deployerMinorVersion: "0"
-deployerBuildVersion: "7"
+deployerMinorVersion: "1"
+deployerBuildVersion: "0"
 
 #executionPath is where the files associated with your deploy will get created
 #and where you will find your deployment summary file.


### PR DESCRIPTION
* Swap out CMD for ENTRYPOINT. This allows us to run the container
without having to specify the entrypoint argument.
* The existing documentation around invoking the container is
still accurate, but now we don't need to supply entrypoint, ruby,
main.rb on the command line, we only need to supply the CLI arguments.