### PR TITLE
[DEMO-2502] Convert to using requirements files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,30 +12,6 @@ RUN apt-get install -y python3-pip python3-dev \
   && cd /usr/local/bin \
   && ln -s /usr/bin/python3 python \
   && pip3 install --upgrade pip
-RUN python3 -m pip install --upgrade setuptools
-
-# Install Ansible
-RUN python3 -m pip install ansible==2.9.9
-# AWS
-RUN python3 -m pip install boto3
-RUN python3 -m pip install botocore
-RUN python3 -m pip install boto
-RUN ansible-galaxy collection install community.aws
-# Azure
-RUN python3 -m pip install ansible[azure]
-RUN python3 -m pip install packaging
-RUN python3 -m pip install msrestazure
-# GCP
-RUN python3 -m pip install requests google-auth
-RUN ansible-galaxy collection install google.cloud
-# NewRelic
-RUN ansible-galaxy install newrelic.newrelic_java_agent
-# Windows
-RUN python3 -m pip install pywinrm
-RUN ansible-galaxy collection install ansible.windows
-
-# MySQL
-RUN ansible-galaxy collection install community.mysql
 
 # Others
 RUN apt-get update
@@ -54,6 +30,14 @@ ADD . /mnt/deployer
 WORKDIR /mnt/deployer
 
 RUN bundle install --clean --force
+
+# Install Python dependencies
+RUN python3 -m pip install -r requirements.python.txt
+
+# Install Ansible dependencies
+# Need two install steps while on v2.9 of Ansible. Next minor version introduces a single install command.
+RUN ansible-galaxy role install -r requirements.ansible.yml
+RUN ansible-galaxy collection install -r requirements.ansible.yml
 
 # CMD [ "ruby", "--version"]
 # CMD [ "python", "--version"]

--- a/requirements.ansible.yml
+++ b/requirements.ansible.yml
@@ -1,8 +1,10 @@
 ---
 roles:
   - newrelic.newrelic_java_agent
+  - newrelic.newrelic-infra
 
 collections:
   - community.aws
   - google.cloud
   - ansible.windows
+  - community.mysql

--- a/requirements.ansible.yml
+++ b/requirements.ansible.yml
@@ -2,7 +2,6 @@
 roles:
   # New Relic
   - newrelic.newrelic_java_agent
-  - newrelic.newrelic-infra
 
 collections:
   # AWS

--- a/requirements.ansible.yml
+++ b/requirements.ansible.yml
@@ -1,10 +1,18 @@
 ---
 roles:
+  # New Relic
   - newrelic.newrelic_java_agent
   - newrelic.newrelic-infra
 
 collections:
+  # AWS
   - community.aws
+
+  # GCP
   - google.cloud
+
+  # Windows
   - ansible.windows
+  
+  # MySQL
   - community.mysql

--- a/requirements.ansible.yml
+++ b/requirements.ansible.yml
@@ -1,0 +1,8 @@
+---
+roles:
+  - newrelic.newrelic_java_agent
+
+collections:
+  - community.aws
+  - google.cloud
+  - ansible.windows

--- a/requirements.python.txt
+++ b/requirements.python.txt
@@ -1,0 +1,10 @@
+setuptools
+ansible==2.9.9
+boto3
+botocore
+boto
+ansible[azure]
+packaging
+msrestazure
+google-auth
+pywinrm

--- a/requirements.python.txt
+++ b/requirements.python.txt
@@ -1,10 +1,21 @@
+# Generic
 setuptools
+
+# Ansible
 ansible==2.9.9
+
+# AWS
 boto3
 botocore
 boto
+
+# Azure
 ansible[azure]
 packaging
 msrestazure
+
+# GCP
 google-auth
+
+# Windows
 pywinrm

--- a/src/app_config.yml
+++ b/src/app_config.yml
@@ -1,7 +1,7 @@
 ---
 deployerMajorVersion: "3"
 deployerMinorVersion: "1"
-deployerBuildVersion: "4"
+deployerBuildVersion: "5"
 
 #executionPath is where the files associated with your deploy will get created
 #and where you will find your deployment summary file.


### PR DESCRIPTION
* Instead of individually installing modules in the Dockerfile, use
a requirments file for python and ansible to collect the dependencies.
Then in the Dockerfile, install them using -r option.
* This simplifies using the tool locally since all ansible & python
dependencies can be installed in one command, and a dev no longer needs
to hunt down specific dependencies in the Dockerfile.