### PR TITLE
DEMO-2519 : add more verbose output when deployer is running

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ gem 'mocha', '1.8.0'
 gem 'pastel', '~> 0.7.2'
 gem 'rake', '12.3.3'
 gem 'rubocop', require: false
-gem 'tty-spinner', '0.9.0'
+gem 'tty-spinner', '0.9.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,9 +45,9 @@ GEM
       parser (>= 2.7.1.4)
     ruby-progressbar (1.10.1)
     tty-color (0.4.3)
-    tty-cursor (0.6.1)
-    tty-spinner (0.9.0)
-      tty-cursor (~> 0.6.0)
+    tty-cursor (0.7.1)
+    tty-spinner (0.9.3)
+      tty-cursor (~> 0.7)
     unicode-display_width (1.7.0)
 
 PLATFORMS
@@ -61,7 +61,7 @@ DEPENDENCIES
   pastel (~> 0.7.2)
   rake (= 12.3.3)
   rubocop
-  tty-spinner (= 0.9.0)
+  tty-spinner (= 0.9.3)
 
 BUNDLED WITH
    1.17.3

--- a/src/app_config.yml
+++ b/src/app_config.yml
@@ -1,7 +1,7 @@
 ---
 deployerMajorVersion: "3"
-deployerMinorVersion: "1"
-deployerBuildVersion: "6"
+deployerMinorVersion: "2"
+deployerBuildVersion: "1"
 
 #executionPath is where the files associated with your deploy will get created
 #and where you will find your deployment summary file.

--- a/src/common/ansible/play.rb
+++ b/src/common/ansible/play.rb
@@ -9,16 +9,11 @@ module Common
         @host_exist = host_exist
         @on_executed_handlers = on_executed_handlers
         @output_file_path = nil
-
-        @log_token = Common::Logger::LoggerFactory.get_logger().add_sub_task_top(play_name)
+        @log_token = Common::Logger::LoggerFactory.get_logger().add_sub_task(play_name)
       end
 
-      # def get_log_token
-      #   return @log_token
-      # end
-
       def start()
-        @log_token.get_ref().auto_spin()
+        @log_token.start()
       end
 
       def success()

--- a/src/common/ansible/play.rb
+++ b/src/common/ansible/play.rb
@@ -1,17 +1,40 @@
 module Common
   module Ansible
     class Play
-      def initialize(script_path, host_file_path, execution_path, host_exist = true, on_executed_handlers = [])
+      def initialize(play_name, script_path, host_file_path, execution_path, host_exist = true, on_executed_handlers = [])
+        @play_name = play_name
         @script_path = script_path
         @host_file_path = host_file_path
         @execution_path = execution_path
         @host_exist = host_exist
         @on_executed_handlers = on_executed_handlers
         @output_file_path = nil
+
+        @log_token = Common::Logger::LoggerFactory.get_logger().add_sub_task_top(play_name)
+      end
+
+      # def get_log_token
+      #   return @log_token
+      # end
+
+      def start()
+        @log_token.get_ref().auto_spin()
+      end
+
+      def success()
+        @log_token.success()
+      end
+
+      def error()
+        @log_token.error()
       end
 
       def host_exist?()
         return @host_exist
+      end
+
+      def get_play_name()
+        return @play_name
       end
 
       def get_script_path()

--- a/src/common/ansible/player.rb
+++ b/src/common/ansible/player.rb
@@ -18,6 +18,8 @@ module Common
       def execute(isAsync = true)
         processes = []
         @plays.each do |play|
+           play.start()
+
           script_path = play.get_script_path()
           host_file_path = play.get_host_file_path()
           execution_path = play.get_execution_path()
@@ -45,11 +47,19 @@ module Common
           lambda_on_start = lambda do |pid|
               Common::Logger::LoggerFactory.get_logger().debug("Running 'ansible-playbook' with command: #{command} and execution_path: #{execution_path}, pid: #{pid}")
           end
-          pid = process.start(lambda_on_start)
+
+          lambda_on_end = lambda do |pid|
+            play.success()
+          end
+
+          pid = process.start(lambda_on_start, lambda_on_end)
           processes.push(process)
+
           unless isAsync
             process.wait_to_completion()
+            play.success()
           end
+
         end
 
         errors = []
@@ -69,6 +79,7 @@ module Common
           else
             message = "#{script_path} exit_code:#{exit_code}, executed in #{process.get_execution_time()}s"
             errors.push("#{message} output:#{output_content}")
+            @play.error()
           end
 
         end

--- a/src/common/ansible/player.rb
+++ b/src/common/ansible/player.rb
@@ -18,8 +18,6 @@ module Common
       def execute(isAsync = true)
         processes = []
         @plays.each do |play|
-           play.start()
-
           script_path = play.get_script_path()
           host_file_path = play.get_host_file_path()
           execution_path = play.get_execution_path()
@@ -79,7 +77,7 @@ module Common
           else
             message = "#{script_path} exit_code:#{exit_code}, executed in #{process.get_execution_time()}s"
             errors.push("#{message} output:#{output_content}")
-            @play.error()
+            play.error()
           end
 
         end

--- a/src/common/install/composer.rb
+++ b/src/common/install/composer.rb
@@ -1,5 +1,6 @@
 require './src/common/logger/logger_factory'
 require './src/common/template_merger'
+require './src/common/Io/directory_service'
 
 require './src/common/install/templates/hosts_template_context'
 require './src/common/install/templates/ansible_template_context'
@@ -23,12 +24,12 @@ module Install
 
       install_definitions.each do |install_definition|
         provisioned_resource = install_definition.get_provisioned_resource()
+        service_id = install_definition.get_service_id()
         erb_input_path = install_definition.get_erb_input_path()
         yaml_output_path = install_definition.get_yaml_output_path()
         roles_path = install_definition.get_roles_path()
         action_vars = install_definition.get_action_vars()
         output_params = install_definition.get_output_params()
-
         base_role_path = roles_path.split(":")[0]
         action_directory_path = Common::Io::DirectoryService.combine_paths(
           base_role_path,
@@ -57,7 +58,7 @@ module Install
           action_context = Common::Install::Templates::ActionTemplateContext.new(action_name, erb_input_path, absolute_yaml_output_path, provisioned_resource, action_vars)
           template_contexts.push(action_context)
 
-          install_context = Common::Install::InstallContext.new(absolute_yaml_output_path, action_context, host_template_context, output_params)
+          install_context = Common::Install::InstallContext.new(service_id, absolute_yaml_output_path, action_context, host_template_context, output_params)
           install_contexts.push(install_context)
 
         else

--- a/src/common/install/composer.rb
+++ b/src/common/install/composer.rb
@@ -1,6 +1,6 @@
 require './src/common/logger/logger_factory'
 require './src/common/template_merger'
-require './src/common/Io/directory_service'
+require './src/common/io/directory_service'
 
 require './src/common/install/templates/hosts_template_context'
 require './src/common/install/templates/ansible_template_context'

--- a/src/common/install/definitions/install_definition.rb
+++ b/src/common/install/definitions/install_definition.rb
@@ -3,19 +3,24 @@ module Common
     module Definitions
       class InstallDefinition
 
-        def initialize(provisioned_resource,
+        def initialize(service_id,
+                      provisioned_resource,
                       erb_input_path,
                       yaml_output_path,
                       roles_path,
                       action_vars_lambda = nil,
                       output_params = nil)
-
+          @service_id = service_id
           @provisioned_resource = provisioned_resource
           @erb_input_path = erb_input_path
           @yaml_output_path = yaml_output_path
           @roles_path = roles_path
           @action_vars_lambda = action_vars_lambda || lambda { return {} }
           @output_params = output_params
+        end
+
+        def get_service_id()
+          return @service_id
         end
 
         def get_provisioned_resource()

--- a/src/common/install/install_context.rb
+++ b/src/common/install/install_context.rb
@@ -2,11 +2,16 @@ module Common
   module Install
     class InstallContext
 
-      def initialize(template_output_path, template_context, host_template_context, output_params = nil)
+      def initialize(service_id, template_output_path, template_context, host_template_context, output_params = nil)
+        @service_id = service_id
         @template_output_path = template_output_path
         @template_context = template_context
         @host_template_context = host_template_context
         @output_params = output_params
+      end
+
+      def get_service_id()
+        return @service_id
       end
 
       def get_host_file_path()

--- a/src/common/install/installer.rb
+++ b/src/common/install/installer.rb
@@ -85,7 +85,7 @@ module Common
           end
           Common::Logger::LoggerFactory.get_logger().debug("Installer() execution_path:#{action_execution_path} execution_path_exist:#{directory_exist} host_file_path:#{host_file_path} script_path:#{script_path} host_exist:#{host_exist}")
           if directory_exist == true
-            play = Common::Ansible::Play.new("#{install_context.get_service_id()} -- #{action_name}", script_path, host_file_path, action_execution_path, host_exist, on_executed_handlers)
+            play = Common::Ansible::Play.new("#{install_context.get_service_id()} running #{action_name;}", script_path, host_file_path, action_execution_path, host_exist, on_executed_handlers)
             player.stack(play)
           end
         end

--- a/src/common/install/installer.rb
+++ b/src/common/install/installer.rb
@@ -85,7 +85,7 @@ module Common
           end
           Common::Logger::LoggerFactory.get_logger().debug("Installer() execution_path:#{action_execution_path} execution_path_exist:#{directory_exist} host_file_path:#{host_file_path} script_path:#{script_path} host_exist:#{host_exist}")
           if directory_exist == true
-            play = Common::Ansible::Play.new(script_path, host_file_path, action_execution_path, host_exist, on_executed_handlers)
+            play = Common::Ansible::Play.new("#{install_context.get_service_id()} -- #{action_name}", script_path, host_file_path, action_execution_path, host_exist, on_executed_handlers)
             player.stack(play)
           end
         end
@@ -102,9 +102,9 @@ module Common
       end
 
       def read_params_output(output_params, artifact_filename)
-        if File.exists?(artifact_filename) 
+        if File.exists?(artifact_filename)
           reader = Common::Install::ParamsReader.new(output_params)
-          reader.read_from_file(artifact_filename) 
+          reader.read_from_file(artifact_filename)
         end
       end
 

--- a/src/common/logger/debug_logger.rb
+++ b/src/common/logger/debug_logger.rb
@@ -7,7 +7,7 @@ module Common
 
       def task_start(task_name)
         puts "Task '#{task_name}': - Started"
-        return LogTaskToken.new(lambda { return task_success(task_name)}, lambda { return task_error(task_name)})
+        return LogTaskToken.new(lambda {}, lambda {}, lambda { return task_success(task_name)}, lambda { return task_error(task_name)})
       end
 
       def debug(message)

--- a/src/common/logger/log_task_token.rb
+++ b/src/common/logger/log_task_token.rb
@@ -2,19 +2,32 @@ module Common
   module Logger
     class LogTaskToken
 
-      def initialize(success_handler = nil, error_handler = nil)
+      def initialize(get_ref_handler = nil, success_handler = nil, error_handler = nil)
+        @get_ref_handler = get_ref_handler
         @success_handler = success_handler
         @error_handler = error_handler
       end
 
+      def get_ref()
+        if @get_ref_handler != nil
+          @get_ref_handler.call()
+        end
+      end
+
       def success()
-        if @success_handler!=nil
+        if @success_handler != nil
+          @success_handler.call()
+        end
+      end
+
+      def pause()
+        if @success_handler != nil
           @success_handler.call()
         end
       end
 
       def error()
-        if @error_handler!=nil
+        if @error_handler != nil
           @error_handler.call()
         end
       end

--- a/src/common/logger/log_task_token.rb
+++ b/src/common/logger/log_task_token.rb
@@ -2,15 +2,15 @@ module Common
   module Logger
     class LogTaskToken
 
-      def initialize(get_ref_handler = nil, success_handler = nil, error_handler = nil)
-        @get_ref_handler = get_ref_handler
+      def initialize(registartion_handler = nil, success_handler = nil, error_handler = nil)
+        @registartion_handler = registartion_handler
         @success_handler = success_handler
         @error_handler = error_handler
       end
 
-      def get_ref()
-        if @get_ref_handler != nil
-          @get_ref_handler.call()
+      def register(sub_task)
+        if @registartion_handler != nil
+          @registartion_handler.call(sub_task)
         end
       end
 

--- a/src/common/logger/logger.rb
+++ b/src/common/logger/logger.rb
@@ -12,6 +12,10 @@ module Common
 
       def error(message) end
 
+      def add_sub_task(task_name)
+        return LogTaskToken.new(lambda {}, lambda {}, lambda {})
+      end
+
       private
       def task_success(task_name) end
 

--- a/src/common/logger/sub_task_logger.rb
+++ b/src/common/logger/sub_task_logger.rb
@@ -1,0 +1,59 @@
+require "tty-spinner"
+require "pastel"
+require "./src/common/logger/logger"
+require "./src/common/logger/log_task_token"
+
+module Common
+  module Logger
+    class SubTaskLogger < Logger
+
+      def initialize(task_parent_token)
+        @task_parent_token = task_parent_token
+        @pastel = Pastel.new()
+      end
+
+      def task_start(task_name)
+        if @task_parent_token.nil?
+          return LogTaskToken.new(lambda {}, lambda {}, lambda {})
+        end
+        spin = @task_parent_token.register("[:spinner] #{task_name}")
+        spin.auto_spin
+        return LogTaskToken.new(lambda {},
+                                lambda { task_pause(spin) },
+                                lambda { task_error(spin) })
+      end
+
+      def info(message)
+        output_message("[INFO]", message)
+      end
+
+      def error(message)
+        output_message("[ERROR]", message)
+      end
+
+      private
+      def task_register(task_handler)
+        task_handler.register()
+      end
+
+      def task_success(task_handler)
+        deregister_handler(task_handler)
+        task_handler.success()
+      end
+
+      def task_pause(task_handler)
+        deregister_handler(task_handler)
+        task_handler.pause()
+      end
+
+      def task_error(task_handler)
+        deregister_handler(task_handler)
+        task_handler.error()
+      end
+
+      def deregister_handler(task_handler)
+      end
+
+    end
+  end
+end

--- a/src/common/tasks/process_task.rb
+++ b/src/common/tasks/process_task.rb
@@ -14,8 +14,8 @@ module Common
         @processs_output = nil
       end
 
-      def start(lambda_on_start = nil)
-        @thread ||= inner_start(lambda_on_start)
+      def start(lambda_on_start = nil, lambda_on_end = nil)
+        @thread ||= inner_start(lambda_on_start, lambda_on_end)
       end
 
       def wait_to_completion()
@@ -46,11 +46,11 @@ module Common
       end
 
       private
-      def inner_start(lambda_on_start = nil)
+      def inner_start(lambda_on_start = nil, lambda_on_end = nil)
         thread = Thread.new{
           processs_output = nil
           @time = Benchmark.measure {
-            processs_output = spawn_process(lambda_on_start)
+            processs_output = spawn_process(lambda_on_start, lambda_on_end)
           }
           processs_output
         }
@@ -58,7 +58,7 @@ module Common
         return thread
       end
 
-      def spawn_process(lambda_on_start = nil)
+      def spawn_process(lambda_on_start = nil, lambda_on_end = nil)
         rout, wout = IO.pipe
         rerr, werr = IO.pipe
 
@@ -81,6 +81,9 @@ module Common
         ensure
           wout.close
           werr.close
+          unless lambda_on_end.nil?
+            lambda_on_end.call(pid)
+          end
         end
 
         stdout = rout.readlines.join("")

--- a/src/deployment/orchestrator.rb
+++ b/src/deployment/orchestrator.rb
@@ -5,19 +5,22 @@ require_relative "provider"
 
 module Deployment
   class Orchestrator
-    
+
     def initialize(context, validator = Deployment::Validator.new)
       @context = context
       @validator = validator
     end
 
     def execute()
+      log_token = Common::Logger::LoggerFactory.get_logger().add_sub_task('Validating instrumentations')
       validation_errors = @validator.execute(@context)
       unless validation_errors.empty?
+        log_token.error()
         raise Common::ValidationError.new("Deployment validation has failed", validation_errors)
       end
       provider = Deployment::Provider.new(@context)
       @context.set_deployment_provider(provider)
+      log_token.success()
       return provider
     end
   end

--- a/src/infrastructure/orchestrator.rb
+++ b/src/infrastructure/orchestrator.rb
@@ -18,6 +18,8 @@ module Infrastructure
     end
 
     def execute(deploy_config_content = nil)
+      log_token = Common::Logger::LoggerFactory.get_logger().add_sub_task('Validating resources')
+
       command_line_provider = @context.get_command_line_provider()
       if deploy_config_content.nil?
         deploy_config_content = command_line_provider.get_deployment_config_content()
@@ -26,11 +28,13 @@ module Infrastructure
       if @is_validation_enabled
         validation_errors = get_validator().execute(parsed_resources)
         unless validation_errors.empty?
+          log_token.error()
           raise Common::ValidationError.new("Infrastructure validation has failed", validation_errors)
         end
       end
       provider = Infrastructure::Provider.new(@context, parsed_resources)
       @context.set_infrastructure_provider(provider)
+      log_token.success()
       return provider
     end
 

--- a/src/install/install_definitions/global_instrumentation_builder.rb
+++ b/src/install/install_definitions/global_instrumentation_builder.rb
@@ -29,7 +29,7 @@ module Install
         yaml_output_path = get_yaml_output_path(instrumentor)
         action_vars_lambda = lambda { return get_action_vars(instrumentor, params) }
         # Don't forget to pass the global instrumentationn to the install definition
-        return Common::Install::Definitions::InstallDefinition.new(nil, get_erb_input_path(), yaml_output_path, roles_path, action_vars_lambda)
+        return Common::Install::Definitions::InstallDefinition.new(global_id, nil, get_erb_input_path(), yaml_output_path, roles_path, action_vars_lambda)
       end
 
       def get_action_vars(instrumentor, params = {})

--- a/src/install/install_definitions/on_host_instrumentation_builder.rb
+++ b/src/install/install_definitions/on_host_instrumentation_builder.rb
@@ -32,7 +32,7 @@ module Install
         roles_path = get_roles_path(instrumentor)
         yaml_output_path = get_yaml_output_path(instrumentor, resource_id)
         action_vars_lambda = lambda { return get_action_vars(instrumentor, provisioned_resource, params) }
-        return Common::Install::Definitions::InstallDefinition.new(provisioned_resource, get_erb_input_path(), yaml_output_path, roles_path, action_vars_lambda)
+        return Common::Install::Definitions::InstallDefinition.new(resource_id, provisioned_resource, get_erb_input_path(), yaml_output_path, roles_path, action_vars_lambda)
       end
 
       def get_action_vars(instrumentor, provisioned_resource, params = {})

--- a/src/install/install_definitions/service_builder.rb
+++ b/src/install/install_definitions/service_builder.rb
@@ -43,7 +43,8 @@ module Install
         yaml_output_path = get_yaml_output_path(service, resource_id)
         action_vars_lambda = lambda { return get_action_vars(service, provisioned_resource, params) }
         output_params = service.get_params()
-        return Common::Install::Definitions::InstallDefinition.new(provisioned_resource, get_erb_input_path(), yaml_output_path, roles_path, action_vars_lambda, output_params)
+        service_id = service.get_id()
+        return Common::Install::Definitions::InstallDefinition.new(service_id, provisioned_resource, get_erb_input_path(), yaml_output_path, roles_path, action_vars_lambda, output_params)
       end
 
       def get_action_vars(service, provisioned_resource, params)

--- a/src/install/install_definitions/service_instrumentation_builder.rb
+++ b/src/install/install_definitions/service_instrumentation_builder.rb
@@ -45,7 +45,7 @@ module Install
         yaml_output_path = get_yaml_output_path(instrumentor, service, resource_id)
         action_vars_lambda = lambda { return get_action_vars(instrumentor, service, provisioned_resource, params) }
         output_params = service.get_params()
-        return Common::Install::Definitions::InstallDefinition.new(provisioned_resource, get_erb_input_path(), yaml_output_path, roles_path, action_vars_lambda, output_params)
+        return Common::Install::Definitions::InstallDefinition.new(service.get_id(), provisioned_resource, get_erb_input_path(), yaml_output_path, roles_path, action_vars_lambda, output_params)
       end
 
       def get_action_vars(instrumentor, service, provisioned_resource, params = {})

--- a/src/install/install_orchestrator.rb
+++ b/src/install/install_orchestrator.rb
@@ -38,7 +38,7 @@ module Install
       return install_definitions
     end
 
-    def execute_global_instrumentation_install(provisioned_resources) 
+    def execute_global_instrumentation_install(provisioned_resources)
       install_definitions = get_install_definitions_builder(provisioned_resources)
                                 .with_global_instrumentations()
                                 .build()

--- a/src/provision/definitions/provisioned_resource.rb
+++ b/src/provision/definitions/provisioned_resource.rb
@@ -41,7 +41,7 @@ module Provision
       def get_type()
         return @resource.get_type()
       end
-      
+
       def get_provider()
         return @resource.get_provider()
       end

--- a/src/provision/orchestrator.rb
+++ b/src/provision/orchestrator.rb
@@ -26,7 +26,6 @@ module Provision
 
     def execute(is_provisioning_enabled = true)
       log_token = Common::Logger::LoggerFactory.get_logger().task_start("Provisioner")
-      @provisioner.set_info_logger_token(log_token)
       provider = Provision::Provider.new(get_infrastructure_provider())
       @context.set_provision_provider(provider)
       deployment_name = get_command_line_provider().get_deployment_name()

--- a/src/provision/orchestrator.rb
+++ b/src/provision/orchestrator.rb
@@ -26,6 +26,7 @@ module Provision
 
     def execute(is_provisioning_enabled = true)
       log_token = Common::Logger::LoggerFactory.get_logger().task_start("Provisioner")
+      @provisioner.set_info_logger_token(log_token)
       provider = Provision::Provider.new(get_infrastructure_provider())
       @context.set_provision_provider(provider)
       deployment_name = get_command_line_provider().get_deployment_name()

--- a/src/provision/provisioner.rb
+++ b/src/provision/provisioner.rb
@@ -9,18 +9,9 @@ module Provision
       @player_construct_lambda = player_construct_lambda
     end
 
-    def set_info_logger_token(info_logger_token)
-      @info_logger_token = info_logger_token
-    end
-
-    def get_info_logger_token()
-      @info_logger_token
-    end
-
     def execute(template_contexts, isAsync = true)
       player = @player_construct_lambda.call()
 
-      log_token = nil
       template_contexts.each do |template_context|
         id = template_context.get_resource().get_id()
 
@@ -35,7 +26,7 @@ module Provision
         end
         Common::Logger::LoggerFactory.get_logger().debug("Provisioner() execution_path:#{execution_path} execution_path_exist:#{directory_exist}")
         if directory_exist == true
-          play = Common::Ansible::Play.new(id, script_path, nil, execution_path, nil, on_executed_handlers)
+          play = Common::Ansible::Play.new("Provisioning #{id}", script_path, nil, execution_path, nil, on_executed_handlers)
           player.stack(play)
         end
       end

--- a/src/provision/provisioner.rb
+++ b/src/provision/provisioner.rb
@@ -9,9 +9,21 @@ module Provision
       @player_construct_lambda = player_construct_lambda
     end
 
+    def set_info_logger_token(info_logger_token)
+      @info_logger_token = info_logger_token
+    end
+
+    def get_info_logger_token()
+      @info_logger_token
+    end
+
     def execute(template_contexts, isAsync = true)
       player = @player_construct_lambda.call()
+
+      log_token = nil
       template_contexts.each do |template_context|
+        id = template_context.get_resource().get_id()
+
         execution_path = template_context.get_execution_path()
         directory_exist = File.directory?(execution_path)
         script_path = template_context.get_template_output_file_path()
@@ -23,7 +35,7 @@ module Provision
         end
         Common::Logger::LoggerFactory.get_logger().debug("Provisioner() execution_path:#{execution_path} execution_path_exist:#{directory_exist}")
         if directory_exist == true
-          play = Common::Ansible::Play.new(script_path, nil, execution_path, nil, on_executed_handlers)
+          play = Common::Ansible::Play.new(id, script_path, nil, execution_path, nil, on_executed_handlers)
           player.stack(play)
         end
       end
@@ -40,9 +52,9 @@ module Provision
 
     private
     def read_params_output(output_params, artifact_filename)
-      if File.exists?(artifact_filename) 
+      if File.exists?(artifact_filename)
         reader = Common::Install::ParamsReader.new(output_params)
-        reader.read_from_file(artifact_filename) 
+        reader.read_from_file(artifact_filename)
       end
     end
 

--- a/src/provision/templates/aws/ec2/template.erb
+++ b/src/provision/templates/aws/ec2/template.erb
@@ -71,7 +71,7 @@
          aws_secret_key: "{{ secret_key }}"
          region: "{{ region }}"
          instance_type: "{{ instance_size }}"
-         image: 
+         image:
           id: "{{ ami_id }}"
          security_groups: "{{ resource_name }}"
          vpc_subnet_id: "{{default_vpc_subnet_id}}"

--- a/src/services/orchestrator.rb
+++ b/src/services/orchestrator.rb
@@ -25,6 +25,8 @@ module Services
     end
 
     def execute(deploy_config_content = nil)
+      log_token = Common::Logger::LoggerFactory.get_logger().add_sub_task('Validating services')
+
       command_line_provider = @context.get_command_line_provider()
       deployment_name = command_line_provider.get_deployment_name()
 
@@ -32,10 +34,10 @@ module Services
 
       app_config_provider = @context.get_app_config_provider()
       execution_path = app_config_provider.get_execution_path()
-      
+
       infrastructure_provider = @context.get_infrastructure_provider()
       resources = infrastructure_provider.get_all()
-      
+
       if deploy_config_content.nil?
         deploy_config_content = command_line_provider.get_deployment_config_content()
       end
@@ -43,6 +45,7 @@ module Services
       if @is_validation_enabled
         validation_errors = get_validator().execute(services, resources, app_config_provider)
         unless validation_errors.empty?
+          log_token.error()
           raise Common::ValidationError.new("Service definition validation has failed", validation_errors)
         end
       end
@@ -50,6 +53,7 @@ module Services
       source_paths_file = get_source_paths_file(services, execution_path, deployment_name)
       provider = Services::Provider.new(services, source_paths_file, tags_provider)
       @context.set_services_provider(provider)
+      log_token.success()
       return provider
     end
 
@@ -58,7 +62,7 @@ module Services
     def get_source_paths_file(services, execution_path, deployment_name)
       file = {}
       services.each do |service|
-        service_id = service["id"]           
+        service_id = service["id"]
         destination_path = "#{execution_path}/#{deployment_name}/#{service_id}"
 
         if service["local_source_path"]
@@ -67,7 +71,7 @@ module Services
           file[service_id] = full_source_path
         else
           source_repository = service["source_repository"]
-          cloned_source_path = get_git_proxy().clone(source_repository, destination_path) 
+          cloned_source_path = get_git_proxy().clone(source_repository, destination_path)
           file[service_id] = cloned_source_path
         end
       end

--- a/src/tags/orchestrator.rb
+++ b/src/tags/orchestrator.rb
@@ -16,6 +16,8 @@ module Tags
     end
 
     def execute(deploy_config_content = nil)
+      log_token = Common::Logger::LoggerFactory.get_logger().add_sub_task('Validating tags')
+
       command_line_provider = @context.get_command_line_provider()
       if deploy_config_content.nil?
         deploy_config_content = command_line_provider.get_deployment_config_content()
@@ -25,6 +27,7 @@ module Tags
       global_tags = parsed_output.get_global_tags()
       validation_errors = @validator.execute(global_tags)
       unless validation_errors.empty?
+        log_token.error()
         raise Common::ValidationError.new("Global tags failed validation: ", validation_errors)
       end
 
@@ -33,6 +36,7 @@ module Tags
         validation_errors = @validator.execute(service_tags)
         unless validation_errors.empty?
           raise Common::ValidationError.new("Service tags failed validation for service id '#{service_id}': ", validation_errors)
+          log_token.error()
         end
       end
 
@@ -41,11 +45,13 @@ module Tags
         validation_errors = @validator.execute(resource_tags)
         unless validation_errors.empty?
           raise Common::ValidationError.new("Resource tags failed validation for resource id '#{resource_id}': ", validation_errors)
+          log_token.error()
         end
       end
 
       provider = Tags::Provider.new(@context, global_tags, services_tags, resources_tags)
       @context.set_tags_provider(provider)
+      log_token.success()
       return provider
     end
 

--- a/src/teardown/orchestrator.rb
+++ b/src/teardown/orchestrator.rb
@@ -19,7 +19,7 @@ module Teardown
         composer = nil,
         terminator = nil,
         summary = nil,
-        post_actions_orchestrator = nil, 
+        post_actions_orchestrator = nil,
         provision_orchestrator = nil,
         uninstall_orchestrator = nil
       )
@@ -34,12 +34,11 @@ module Teardown
     end
 
     def execute()
+      execute_provisioner()
       log_token = Common::Logger::LoggerFactory.get_logger().task_start("Terminating infrastructure")
 
-      execute_provisioner()
       target_provisioned_resources = get_resources_target()
       Common::Logger::LoggerFactory.get_logger().debug("Uninstalling on #{target_provisioned_resources.length} resources")
-
       provisioned_resources_by_group = partition_by_provision_group_descending(target_provisioned_resources)
       if provisioned_resources_by_group.any?
         provisioned_resources_by_group.each do |provisioned_resources|
@@ -53,11 +52,9 @@ module Teardown
       else
         get_uninstall_orchestrator().execute([])
       end
-
       get_post_actions_orchestrator().execute()
 
       log_token.success()
-
       get_summary().execute()
     end
 

--- a/src/teardown/terminator.rb
+++ b/src/teardown/terminator.rb
@@ -23,7 +23,7 @@ module Teardown
         end
         Common::Logger::LoggerFactory.get_logger().debug("Terminator() execution_path:#{execution_path} execution_path_exist:#{directory_exist}")
         if directory_exist == true
-          play = Common::Ansible::Play.new(script_path, nil, execution_path, nil, on_executed_handlers)
+          play = Common::Ansible::Play.new("#{template_context.get_resource_id()} :: teardown", script_path, nil, execution_path, nil, on_executed_handlers)
           player.stack(play)
         end
       end
@@ -40,9 +40,9 @@ module Teardown
 
     private
     def read_params_output(output_params, artifact_filename)
-      if File.exists?(artifact_filename) 
+      if File.exists?(artifact_filename)
         reader = Common::Install::ParamsReader.new(output_params)
-        reader.read_from_file(artifact_filename) 
+        reader.read_from_file(artifact_filename)
       end
     end
 

--- a/src/teardown/terminator.rb
+++ b/src/teardown/terminator.rb
@@ -23,7 +23,7 @@ module Teardown
         end
         Common::Logger::LoggerFactory.get_logger().debug("Terminator() execution_path:#{execution_path} execution_path_exist:#{directory_exist}")
         if directory_exist == true
-          play = Common::Ansible::Play.new("#{template_context.get_resource_id()} :: teardown", script_path, nil, execution_path, nil, on_executed_handlers)
+          play = Common::Ansible::Play.new("#{template_context.get_resource_id()} running teardown", script_path, nil, execution_path, nil, on_executed_handlers)
           player.stack(play)
         end
       end

--- a/src/teardown/uninstall_orchestrator.rb
+++ b/src/teardown/uninstall_orchestrator.rb
@@ -38,7 +38,7 @@ module Teardown
       execute_install(install_definitions, "Services and instrumentations")
     end
 
-    def execute_global_instrumentation_install(provisioned_resources) 
+    def execute_global_instrumentation_install(provisioned_resources)
       install_definitions = get_install_definitions_builder(provisioned_resources)
                                 .with_global_instrumentations()
                                 .build()
@@ -47,9 +47,7 @@ module Teardown
 
     def execute_install(install_definitions, target_installation)
       unless install_definitions.empty?
-        @log_token = Common::Logger::LoggerFactory.get_logger().task_start("Uninstalling #{target_installation}")
         (@installer || get_installer()).execute(install_definitions)
-        @log_token.success()
       end
     end
 

--- a/src/user_config/orchestrator.rb
+++ b/src/user_config/orchestrator.rb
@@ -18,6 +18,8 @@ module UserConfig
     end
 
     def execute(user_config_content = nil)
+      log_token = Common::Logger::LoggerFactory.get_logger().add_sub_task('Validating user config')
+
       if user_config_content.nil?
         command_line_provider = @context.get_command_line_provider()
         user_config_content = command_line_provider.get_user_config_content()
@@ -26,13 +28,15 @@ module UserConfig
       if @is_validation_enabled
         validation_errors = @validator.execute(parsed_user_config)
         unless validation_errors.empty?
+          log_token.error()
           raise Common::ValidationError.new("User Configuration failed validation:", validation_errors)
         end
       end
       provider = UserConfig::Provider.new(parsed_user_config)
       @context.set_user_config_provider(provider)
+      log_token.success()
       return provider
     end
-    
+
   end
 end

--- a/tests/common/install/composer_tests.rb
+++ b/tests/common/install/composer_tests.rb
@@ -3,10 +3,12 @@ require "minitest/autorun"
 require "mocha/minitest"
 
 require "./src/common/install/composer"
+require "./src/common/install/installer"
 require "./src/common/install/definitions/install_definition"
 
 describe "Common::Install::Composer" do
   let(:credential) { mock(); }
+  let(:id) { "an_id" }
   let(:provisioned_resource) { m = mock(); m.stubs(:get_credential).returns(credential);m.stubs(:get_user_name).returns("user_name");m.stubs(:get_ip).returns("1.1.1.1"); m}
   let(:install_definitions) { [] }
   let(:directory_service) { m = mock(); m.stubs(:create_sub_directory).returns("/path"); m.stubs(:get_subdirectory_paths).returns(["yaml_path/testAction"]); m }
@@ -30,7 +32,7 @@ describe "Common::Install::Composer" do
     it "should do merge for all 3 templates" do
       Dir.stubs(:exist?).with("#{roles_path}/#{action_name}").returns(true)
       Dir.stubs(:exist?).with("#{yaml_path}/#{action_name}").returns(false)
-      given_install_definition(provisioned_resource, erb_path, yaml_path, roles_path)
+      given_install_definition(id, provisioned_resource, erb_path, yaml_path, roles_path)
       template_merger.expects(:merge_template_save_file).times(3)
       composer.execute(action_name, install_definitions)
     end
@@ -38,7 +40,7 @@ describe "Common::Install::Composer" do
     it "should create action sub-directory" do
       Dir.stubs(:exist?).with("#{roles_path}/#{action_name}").returns(true)
       Dir.stubs(:exist?).with("#{yaml_path}/#{action_name}").returns(false)
-      given_install_definition(provisioned_resource, erb_path, yaml_path, roles_path)
+      given_install_definition(id, provisioned_resource, erb_path, yaml_path, roles_path)
       directory_service.expects(:create_sub_directory).with("#{yaml_path}/#{action_name}")
       composer.execute(action_name, install_definitions)
     end
@@ -46,16 +48,16 @@ describe "Common::Install::Composer" do
     it "should throw when action sub-directory already exists" do
       Dir.stubs(:exist?).with("#{roles_path}/#{action_name}").returns(true)
       Dir.stubs(:exist?).with("#{yaml_path}/#{action_name}").returns(true)
-      given_install_definition(provisioned_resource, erb_path, yaml_path, roles_path)
+      given_install_definition(id, provisioned_resource, erb_path, yaml_path, roles_path)
       error = assert_raises Common::InstallError do
         composer.execute(action_name, install_definitions)
       end
       error.message.must_include("Cannot generate templates for action path #{yaml_path}/#{action_name}")
     end
 
-    def given_install_definition(provisioned_resource, erb_input_path, yaml_output_path, roles_path)
+    def given_install_definition(id, provisioned_resource, erb_input_path, yaml_output_path, roles_path)
       given_logger()
-      install_definition = Common::Install::Definitions::InstallDefinition.new(provisioned_resource, erb_input_path, yaml_output_path, roles_path)
+      install_definition = Common::Install::Definitions::InstallDefinition.new(id, provisioned_resource, erb_input_path, yaml_output_path, roles_path)
       install_definitions.push(install_definition)
     end
 

--- a/tests/provision/actions/pre/aws/fetch_lambda_api_id_tests.rb
+++ b/tests/provision/actions/pre/aws/fetch_lambda_api_id_tests.rb
@@ -26,10 +26,14 @@ describe "Provision::Actions::Pre::Aws::FetchLambdaApiId" do
 
   def given_logger()
     logger = mock()
+    sub_task = mock()
+    sub_task.stubs(:success)
+
     Common::Logger::LoggerFactory.stubs(:get_logger).returns(logger)
     logger.stubs(:debug)
+    logger.stubs(:add_sub_task).returns(sub_task)
   end
-  
+
   def given_resource(id, type)
     context_builder.infrastructure().with_resource(id, {"provider" => "aws", "type" => "#{type}"})
     resource.stubs(:get_id).returns(id)
@@ -41,7 +45,7 @@ describe "Provision::Actions::Pre::Aws::FetchLambdaApiId" do
   def when_action()
     context = context_builder.build()
     return Provision::Actions::Pre::Aws::FetchLambdaApiId.new(
-      context, 
+      context,
       api_gateway_client)
   end
 end

--- a/tests/provision/actions/pre/orchestrator_tests.rb
+++ b/tests/provision/actions/pre/orchestrator_tests.rb
@@ -31,8 +31,11 @@ describe "Provision::Actions::Pre::Orchestrator" do
 
   def given_logger()
     logger = mock()
+    sub_task = mock()
+    sub_task.stubs(:success)
     Common::Logger::LoggerFactory.stubs(:get_logger).returns(logger)
     logger.stubs(:debug)
+    logger.stubs(:add_sub_task).returns(sub_task)
   end
 
   def given_resource(id, type)

--- a/tests/provision/orchestrator_tests.rb
+++ b/tests/provision/orchestrator_tests.rb
@@ -8,8 +8,8 @@ require "./tests/context_builder"
 describe "Provision::Orchestrator" do
   let(:context) { Tests::ContextBuilder.new().build() }
   let(:directory_service) { m = mock(); m.stubs(:create_sub_directory).returns("/path"); m }
-  let(:provisioner) { m = mock(); m.stubs(:execute); m }
-  let(:composer) { m = mock(); m.stubs(:execute); m }    
+  let(:provisioner) { m = mock(); m.stubs(:execute); m.stubs(:set_info_logger_token); m }
+  let(:composer) { m = mock(); m.stubs(:execute); m }
   let(:log_token) { m = mock(); m.stubs(:success).returns(nil); m.stubs(:error).returns(nil);  m }
   let(:pre_actions_orchestrator) { m = mock(); m.stubs(:execute); m }
   let(:orchestrator) { Provision::Orchestrator.new(context, directory_service, provisioner, composer, pre_actions_orchestrator) }

--- a/tests/provision/orchestrator_tests.rb
+++ b/tests/provision/orchestrator_tests.rb
@@ -30,7 +30,10 @@ describe "Provision::Orchestrator" do
   def given_logger()
     logger = mock()
     logger.stubs(:debug)
+    sub_task = mock()
+    sub_task.stubs(:success)
     Common::Logger::LoggerFactory.stubs(:get_logger).returns(logger)
     logger.expects(:task_start).returns(log_token)
+    logger.stubs(:add_sub_task).returns(sub_task)
   end
 end

--- a/tests/teardown/actions/post/aws/finalize_lambda_teardown_tests.rb
+++ b/tests/teardown/actions/post/aws/finalize_lambda_teardown_tests.rb
@@ -12,7 +12,7 @@ describe "Teardown::Actions::Post::Aws::FinalizeLambdaTeardown" do
   let(:resource) { m = mock(); m }
   let(:credential) { m = mock(); m }
   let(:action) { Teardown::Actions::Post::Aws::FinalizeLambdaTeardown.new(
-      context, 
+      context,
       api_gateway_client,
       lambda{ }) }
 
@@ -29,10 +29,13 @@ describe "Teardown::Actions::Post::Aws::FinalizeLambdaTeardown" do
 
   def given_logger()
     logger = mock()
+    sub_task = mock()
+    sub_task.stubs(:success)
     Common::Logger::LoggerFactory.stubs(:get_logger).returns(logger)
     logger.stubs(:debug)
+    logger.stubs(:add_sub_task).returns(sub_task)
   end
-  
+
   def given_resource(id, type)
     resource.stubs(:get_id).returns(id)
     resource.stubs(:get_type).returns(type)

--- a/tests/teardown/actions/post/orchestrator_tests.rb
+++ b/tests/teardown/actions/post/orchestrator_tests.rb
@@ -32,13 +32,16 @@ describe "Teardown::Actions::Post::Orchestrator" do
 
   def given_logger()
     logger = mock()
+    sub_task = mock()
+    sub_task.stubs(:success)
     Common::Logger::LoggerFactory.stubs(:get_logger).returns(logger)
     logger.stubs(:debug)
+    logger.stubs(:add_sub_task).returns(sub_task)
   end
 
   def given_resource(id)
     context_builder.infrastructure().ec2(id)
-  end  
+  end
 
   def when_orchestrator()
     context = context_builder.build()

--- a/tests/teardown/orchestrator_tests.rb
+++ b/tests/teardown/orchestrator_tests.rb
@@ -20,7 +20,7 @@ describe "Teardown::Orchestrator" do
   it "should create orchestrator" do
     when_orchestrator().wont_be_nil()
   end
-  
+
   it "should execute summary" do
     given_logger()
     summary.expects(:execute)
@@ -30,18 +30,22 @@ describe "Teardown::Orchestrator" do
   def given_logger()
     logger = mock()
     logger.stubs(:debug)
+    sub_task = mock()
+    sub_task.stubs(:success)
+
     Common::Logger::LoggerFactory.stubs(:get_logger).returns(logger)
     logger.expects(:task_start).returns(log_token)
+    logger.stubs(:add_sub_task).returns(sub_task)
   end
 
   def when_orchestrator()
     provision_provider = context.get_provision_provider()
     provision_orchestrator.stubs(:execute).returns(provision_provider)
     return Teardown::Orchestrator.new(
-      context, 
+      context,
       directory_service,
-      composer, 
-      terminator, 
+      composer,
+      terminator,
       summary,
       post_actions_orchestrator,
       provision_orchestrator)


### PR DESCRIPTION
This PR adds a bit more details into what the deployer is doing while running in 'info mode'.  Previously there was only 1 line of output for each very high level task the deployer was performing (config/validation, provision, install..).  Now each high level task has sub tasks that are shown.  This should give a better experience for the end user by letting them peek behind the curtain and see that things are still happening.