### PR TITLE
Attempt to fix false detection of error when deployment succeeds in batch mode

### DIFF
--- a/src/app_config.yml
+++ b/src/app_config.yml
@@ -1,7 +1,7 @@
 ---
 deployerMajorVersion: "3"
 deployerMinorVersion: "2"
-deployerBuildVersion: "4"
+deployerBuildVersion: "5"
 
 #executionPath is where the files associated with your deploy will get created
 #and where you will find your deployment summary file.

--- a/tests/batch/runner_tests.rb
+++ b/tests/batch/runner_tests.rb
@@ -110,6 +110,18 @@ describe "Batch::Runner" do
     errors.length().must_equal(2)
   end
 
+  it "should not detect failure when process output indicates success" do
+    given_logger()
+    succeeded = runner.has_deployment_succeeded?(false, "something whatever but Deployment successful! so this is ok")
+    succeeded.must_equal(true)
+  end
+
+  it "should detect failure when process output does NOT indicates success" do
+    given_logger()
+    succeeded = runner.has_deployment_succeeded?(false, "something without any indication of success.")
+    succeeded.must_equal(false)
+  end
+
   def given_success_deployment(user, deploy, partition = nil)
     partition = partition || given_partition()
     deployment = given_deployment(user, deploy, partition)


### PR DESCRIPTION
## Summary

Sometime, the execution of the deployer in batch mode indicates an error, when in facts where was none (deployment successful).
This PR adds a validation to indicate success when the output matches the deployment successful.

https://github.com/newrelic/open-install-library/runs/1813368327?check_suite_focus=true

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [ ] Documentation updated
- [ X] Unit tests updated
- [ ] Integration tests updated
- [ ] User Acceptance Tests updated
- [ X] Deployer version updated

## Deployment Configuration for Testing
[NOTE]: # ( Provide a deployment configuration to use during manual testing, if applicable. )

## Related Issues
[NOTE]: # ( Provide links to any related Github issues. )

## Related Pull Requests
[NOTE]: # ( Provide links to any related pull requests. )

## Reviewers
[NOTE]: # ( Mention reviewers here! )
