### PR TITLE
Demo 2557 wait for lambda

### DIFF
--- a/src/app_config.yml
+++ b/src/app_config.yml
@@ -1,7 +1,7 @@
 ---
 deployerMajorVersion: "3"
 deployerMinorVersion: "3"
-deployerBuildVersion: "0"
+deployerBuildVersion: "1"
 
 #executionPath is where the files associated with your deploy will get created
 #and where you will find your deployment summary file.

--- a/src/provision/templates/aws/lambda/template.erb
+++ b/src/provision/templates/aws/lambda/template.erb
@@ -120,9 +120,11 @@
         memory_size: "{{ memory_size }}"
         tags: "{{ tags }}"
       register: lambda_function
-      retries: 6
+      retries: 30
       delay: 10
-      until: lambda_function is not failed
+      until: 
+        - lambda_function is not failed
+        - "lambda_function.configuration.state == 'Active'"
 
     - name: Create lambda function policy
       lambda_policy:


### PR DESCRIPTION
## Summary

Wait for lambda to be created and ready for use. Currently, in the pr listed below, a minimal python lambda deployment is failing due to steps running while the lambda is still not fully created. This pr adds in an additional check to the lambda creation play to make sure the lambda is ready for use before continuing.

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [x] Deployer version updated

## Deployment Configuration for Testing
[NOTE]: # ( Provide a deployment configuration to use during manual testing, if applicable. )
`{
    "services": [
        {
            "id": "python1",
            "source_repository": "https://github.com/newrelic/demo-pythontron.git",
            "deploy_script_path": "deploy/lambda/roles",
            "destinations": [
                "lambdahost"
            ]
        }
    ],
    "resources": [
        {
            "id": "lambdahost",
            "provider": "aws",
            "type": "lambda"
        }
    ],
    "instrumentations": {}
}`

## Related Pull Requests
[NOTE]: # ( Provide links to any related pull requests. )
https://github.com/newrelic/demo-pythontron/pull/6

## Reviewers
@aswanson-nr 
