### PR TITLE
Updating onbeforestart and onafterstart to be parallel

### DIFF
--- a/documentation/developer/README.md
+++ b/documentation/developer/README.md
@@ -48,9 +48,9 @@ Each of these plays are run in sequence from top to bottom. If a play is not pro
 * upload - parallel
 * instrument - serial
 * configure - serial
-* onbeforestart - serial
+* onbeforestart - parallel
 * start - parallel
-* onafterstart - serial
+* onafterstart - parallel
 
 #### Teardown
 * stop - parallel

--- a/src/app_config.yml
+++ b/src/app_config.yml
@@ -1,7 +1,7 @@
 ---
 deployerMajorVersion: "3"
 deployerMinorVersion: "3"
-deployerBuildVersion: "1"
+deployerBuildVersion: "2"
 
 #executionPath is where the files associated with your deploy will get created
 #and where you will find your deployment summary file.

--- a/src/install/install_orchestrator.rb
+++ b/src/install/install_orchestrator.rb
@@ -67,9 +67,9 @@ module Install
         .queue_step("upload", parallel)
         .queue_step("instrument", serial)
         .queue_step("configure", serial)
-        .queue_step("onbeforestart", serial)
+        .queue_step("onbeforestart", parallel)
         .queue_step("start", parallel)
-        .queue_step("onafterstart", serial)
+        .queue_step("onafterstart", parallel)
       return @installer
     end
 


### PR DESCRIPTION
## Summary

Updating the onbeforestart and onafterstart events to process in parallel versus serial

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [X ] Documentation updated
- [ ] Unit tests updated
- [ ] Integration tests updated
- [ ] User Acceptance Tests updated
- [X ] Deployer version updated

## Reviewers
[NOTE]: @gabeobrien this work should allow us to do those multiple instrumentation validation onafterstart
