### PR TITLE
Fix/win password action

### DIFF
--- a/src/app_config.yml
+++ b/src/app_config.yml
@@ -1,7 +1,7 @@
 ---
 deployerMajorVersion: "3"
 deployerMinorVersion: "3"
-deployerBuildVersion: "2"
+deployerBuildVersion: "3"
 
 #executionPath is where the files associated with your deploy will get created
 #and where you will find your deployment summary file.

--- a/src/common/install/templates/action_template.erb
+++ b/src/common/install/templates/action_template.erb
@@ -2,8 +2,7 @@
 
 - hosts: <%= action_name %>
   vars:
-    output_path: <%= output_path %><% action_vars.each do |key,value| %>
-    <%= key %>: <%= value %><% end %><% params.each do |key,value| %>
-    <%= key %>: <%= value%><% end %>
+    <% action_vars.each do |key,value| %>
+    <%= key %>: <%= value %><% end %>
   roles:
   - <%= action_name %>

--- a/src/common/install/templates/action_template_context.rb
+++ b/src/common/install/templates/action_template_context.rb
@@ -25,15 +25,23 @@ module Common
 
         def get_template_binding()
           template_binding = Kernel.binding()
-
-          template_binding.local_variable_set('output_path', get_execution_path())
           template_binding.local_variable_set('action_name', @action_name)
-          template_binding.local_variable_set('action_vars', @action_vars)
-          params = {}
+
+          all_vars = {
+            output_path: get_execution_path()
+          }
+
+          all_vars.merge(@action_vars)
+
           unless @provisioned_resource.nil?
-            @provisioned_resource.get_params().get_all()
+            params = @provisioned_resource.get_params().get_all()
+            all_vars.merge(params)
           end
-          template_binding.local_variable_set('params', params)
+
+          # windows password should not be passed as action param (not yaml encoded, and not needed)
+          all_vars.delete('win_password')
+
+          template_binding.local_variable_set('action_vars', all_vars)
           return template_binding
         end
 

--- a/src/common/install/templates/action_template_context.rb
+++ b/src/common/install/templates/action_template_context.rb
@@ -31,11 +31,11 @@ module Common
             output_path: get_execution_path()
           }
 
-          all_vars.merge(@action_vars)
+          all_vars = all_vars.merge(@action_vars)
 
           unless @provisioned_resource.nil?
             params = @provisioned_resource.get_params().get_all()
-            all_vars.merge(params)
+            all_vars = all_vars.merge(params)
           end
 
           # windows password should not be passed as action param (not yaml encoded, and not needed)

--- a/src/common/install/templates/action_template_context.rb
+++ b/src/common/install/templates/action_template_context.rb
@@ -31,12 +31,12 @@ module Common
             output_path: get_execution_path()
           }
 
-          all_vars = all_vars.merge(@action_vars)
-
           unless @provisioned_resource.nil?
             params = @provisioned_resource.get_params().get_all()
             all_vars = all_vars.merge(params)
           end
+
+          all_vars = all_vars.merge(@action_vars)
 
           # windows password should not be passed as action param (not yaml encoded, and not needed)
           all_vars.delete('win_password')


### PR DESCRIPTION
## Summary

Fix an issue with windows password making some deploy fails because the password is not yaml encoded. Since the win_password is not required to be passed in as an action var, I've removed it. Note, the password is passed-in through the host file.
I've tested the fix local by deploying both a linux and windows deployment, and verified the absence of the win_password parameter in the action yml

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [ ] Documentation updated
- [ ] Unit tests updated
- [ ] Integration tests updated
- [ ] User Acceptance Tests updated
- [X] Deployer version updated

## Deployment Configuration for Testing
[NOTE]: # ( Provide a deployment configuration to use during manual testing, if applicable. )

## Related Issues
[NOTE]: # ( Provide links to any related Github issues. )

## Related Pull Requests
[NOTE]: # ( Provide links to any related pull requests. )

## Reviewers
[NOTE]: # ( Mention reviewers here! )
