### PR TITLE
fix: default ami version for aws ec2

### DIFF
--- a/src/app_config.yml
+++ b/src/app_config.yml
@@ -1,7 +1,7 @@
 ---
 deployerMajorVersion: "3"
-deployerMinorVersion: "4"
-deployerBuildVersion: "3"
+deployerMinorVersion: "5"
+deployerBuildVersion: "0"
 
 #executionPath is where the files associated with your deploy will get created
 #and where you will find your deployment summary file.

--- a/src/infrastructure/definitions/aws/ec2_resource.rb
+++ b/src/infrastructure/definitions/aws/ec2_resource.rb
@@ -10,7 +10,7 @@ module Infrastructure
 
           @size = size
           @user_name = user_name
-          @ami_name = "amzn2-ami-hvm-2.0.20190228-x86_64-gp2"
+          @ami_name = "amzn2-ami-hvm-2.0.????????-x86_64-gp2"
           @is_windows = false
           @tags = tags
           @cpu_credit_specification = cpu_credit_specification

--- a/src/provision/lookup_templates/aws/ec2/template.erb
+++ b/src/provision/lookup_templates/aws/ec2/template.erb
@@ -22,7 +22,7 @@
   tasks:
     - include_tasks: vpc.yml
 
-    - ec2_instance_facts:
+    - amazon.aws.ec2_instance_info:
         aws_access_key: "{{ access_key }}"
         aws_secret_key: "{{ secret_key }}"
         region: "{{ region }}"

--- a/src/provision/lookup_templates/aws/elb/template.erb
+++ b/src/provision/lookup_templates/aws/elb/template.erb
@@ -20,7 +20,7 @@
 
   tasks:
     - name: Get load balancer fact
-      elb_application_lb_facts:
+      community.aws.elb_application_lb_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{region}}"

--- a/src/provision/lookup_templates/aws/vpc/template.erb
+++ b/src/provision/lookup_templates/aws/vpc/template.erb
@@ -1,7 +1,7 @@
 ---
 - block:
     - name: Get VPC Facts
-      ec2_vpc_net_facts:
+      amazon.aws.ec2_vpc_net_info:
         aws_access_key: <%= vpc[:aws_access_key] %>
         aws_secret_key: <%= vpc[:aws_secret_key] %>
         region: <%= vpc[:region] %>
@@ -18,7 +18,7 @@
       when: default_vpc is not defined
 
     - name: get VPC subnets
-      ec2_vpc_subnet_facts:
+      amazon.aws.ec2_vpc_subnet_info:
         aws_access_key: <%= vpc[:aws_access_key] %>
         aws_secret_key: <%= vpc[:aws_secret_key] %>
         region: <%= vpc[:region] %>

--- a/src/provision/templates/aws/ec2/template.erb
+++ b/src/provision/templates/aws/ec2/template.erb
@@ -23,7 +23,7 @@
     - include_tasks: vpc.yml
 
     - name: Determine AMI ID for EC2 instance
-      ec2_ami_facts:
+      amazon.aws.ec2_ami_info:
         aws_access_key: "{{ access_key }}"
         aws_secret_key: "{{ secret_key }}"
         region: "{{ region }}"
@@ -89,7 +89,7 @@
 <% end %>
       register: ec2
 
-    - ec2_instance_facts:
+    - amazon.aws.ec2_instance_info:
         aws_access_key: "{{ access_key }}"
         aws_secret_key: "{{ secret_key }}"
         region: "{{ region }}"

--- a/src/provision/templates/aws/elb/template.erb
+++ b/src/provision/templates/aws/elb/template.erb
@@ -20,7 +20,7 @@
 
   tasks:
     - name: Get default VPC fact
-      ec2_vpc_net_facts:
+      amazon.aws.ec2_vpc_net_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{region}}"
@@ -33,7 +33,7 @@
         default_vpc_id: "{{ default_vpc.vpcs | map(attribute='id') | list | first }}"
 
     - name: Find availability zones in the default VPC
-      ec2_vpc_subnet_facts:
+      amazon.aws.ec2_vpc_subnet_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{region}}"
@@ -48,7 +48,7 @@
         subnet_ids: "{{ default_subnets.subnets | map(attribute='id') | list }}"
 
     - name: Gather instance facts
-      ec2_instance_facts:
+      amazon.aws.ec2_instance_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{region}}"

--- a/src/provision/templates/aws/r53ip/template.erb
+++ b/src/provision/templates/aws/r53ip/template.erb
@@ -31,7 +31,7 @@
       when: ips is defined and ips is not none
 
     - name: Get load balancer fact
-      elb_application_lb_facts:
+      community.aws.elb_application_lb_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{region}}"

--- a/src/provision/templates/aws/vpc/template.erb
+++ b/src/provision/templates/aws/vpc/template.erb
@@ -1,7 +1,7 @@
 ---
 - block:
     - name: Get VPC Facts
-      ec2_vpc_net_facts:
+      amazon.aws.ec2_vpc_net_info:
         aws_access_key: <%= vpc[:aws_access_key] %>
         aws_secret_key: <%= vpc[:aws_secret_key] %>
         region: <%= vpc[:region] %>
@@ -18,7 +18,7 @@
       when: default_vpc is not defined
 
     - name: get VPC subnets
-      ec2_vpc_subnet_facts:
+      amazon.aws.ec2_vpc_subnet_info:
         aws_access_key: <%= vpc[:aws_access_key] %>
         aws_secret_key: <%= vpc[:aws_secret_key] %>
         region: <%= vpc[:region] %>

--- a/src/teardown/templates/aws/ec2/template.erb
+++ b/src/teardown/templates/aws/ec2/template.erb
@@ -12,7 +12,7 @@
 
   tasks:
     - name: Gather instance facts
-      ec2_instance_facts:
+      amazon.aws.ec2_instance_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{ region }}"
@@ -32,7 +32,7 @@
       when: ec2_facts is defined
 
     - name: Gather group facts
-      ec2_group_facts:
+      amazon.aws.ec2_group_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{ region }}"

--- a/src/teardown/templates/aws/elb/template.erb
+++ b/src/teardown/templates/aws/elb/template.erb
@@ -14,7 +14,7 @@
 
   tasks:
     - name: Get default VPC fact
-      ec2_vpc_net_facts:
+      amazon.aws.ec2_vpc_net_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{ region }}"
@@ -27,7 +27,7 @@
         default_vpc_id: "{{ default_vpc.vpcs | map(attribute='id') | list | first }}"
 
     - name: Get load balancer facts
-      elb_application_lb_facts:
+      community.aws.elb_application_lb_info:
         names: "{{ deployment_name }}-{{ resource_id }}"
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
@@ -46,7 +46,7 @@
       register: elb_result
 
     - name: Gather group facts
-      ec2_group_facts:
+      amazon.aws.ec2_group_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{ region }}"

--- a/src/teardown/templates/aws/lambda/template.erb
+++ b/src/teardown/templates/aws/lambda/template.erb
@@ -53,7 +53,7 @@
         log_group_name: "/aws/lambda/{{ lambda_function_name }}"
 
     - name: Gather group facts
-      ec2_group_facts:
+      amazon.aws.ec2_group_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{ region }}"

--- a/src/teardown/templates/aws/r53ip/template.erb
+++ b/src/teardown/templates/aws/r53ip/template.erb
@@ -39,7 +39,7 @@
       when: ips is defined and ips is not none and record is defined and record.set is defined and record.set.value is defined
 
     - name: Get load balancer fact
-      elb_application_lb_facts:
+      community.aws.elb_application_lb_info:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{region}}"


### PR DESCRIPTION
## Summary

Update default AMI for AWS/EC2 to use the most recently published AMI.

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [ ] Documentation updated
- [ ] Unit tests updated
- [ ] Integration tests updated
- [ ] User Acceptance Tests updated
- [X] Deployer version updated

## Deployment Configuration for Testing
[NOTE]: # ( Provide a deployment configuration to use during manual testing, if applicable. )

## Related Issues
[NOTE]: # ( Provide links to any related Github issues. )

## Related Pull Requests
[NOTE]: # ( Provide links to any related pull requests. )

## Reviewers
[NOTE]: # ( Mention reviewers here! )
