### PR TITLE
feat(summary): add option to write hosts.ini output for all provisioned host resources

### DIFF
--- a/src/app_config.yml
+++ b/src/app_config.yml
@@ -1,12 +1,13 @@
 ---
 deployerMajorVersion: "3"
-deployerMinorVersion: "7"
+deployerMinorVersion: "8"
 deployerBuildVersion: "0"
 
 #executionPath is where the files associated with your deploy will get created
 #and where you will find your deployment summary file.
 executionPath: "/tmp"
 summaryFilename: "deploy_summary.txt"
+summaryIniFilename: "hosts.ini"
 
 #defaultUserConfigPath is available to avoid having to pass one more mount for docker deploys
 defaultUserConfigPath: "configs/*.credentials.local.json"

--- a/src/app_config/provider.rb
+++ b/src/app_config/provider.rb
@@ -23,6 +23,11 @@ module AppConfig
       return filename
     end
 
+    def get_summary_ini_filename()
+      filename = @config_file["summaryIniFilename"]
+      return filename
+    end
+
     def get_user_default_config_path()
       user_config_path = @config_file["defaultUserConfigPath"]
       return user_config_path

--- a/src/command_line/parser.rb
+++ b/src/command_line/parser.rb
@@ -40,7 +40,6 @@ module CommandLine
         options[:user_config] = config
       end
 
-
       @opts.on('-l', '--logging LEVEL', String, 'Logging level used during deployment or teardown. debug, info (default), error') do |logging|
         options[:logging_level] = logging
       end
@@ -57,7 +56,7 @@ module CommandLine
         options[:output_file_path] = file_path
       end
 
-      @opts.on('-i', '--output-ini', FalseClass, 'Specify to write an ini file with the details about the provisioned hosts.') do |config|
+      @opts.on('-n', '--output-ini', FalseClass, 'Specify to write an ini file with the details about the provisioned hosts.') do |config|
         options[:output_ini] = true
       end
 

--- a/src/command_line/parser.rb
+++ b/src/command_line/parser.rb
@@ -57,7 +57,7 @@ module CommandLine
       end
 
       @opts.on('-n', '--output-ini', FalseClass, 'Specify to write an ini file with the details about the provisioned hosts.') do |config|
-        options[:output_ini] = true
+        options[:is_output_ini] = true
       end
 
       return options

--- a/src/command_line/parser.rb
+++ b/src/command_line/parser.rb
@@ -57,6 +57,10 @@ module CommandLine
         options[:output_file_path] = file_path
       end
 
+      @opts.on('-i', '--output-ini', FalseClass, 'Specify to write an ini file with the details about the provisioned hosts.') do |config|
+        options[:output_ini] = true
+      end
+
       return options
     end
 

--- a/src/command_line/provider.rb
+++ b/src/command_line/provider.rb
@@ -75,6 +75,10 @@ module CommandLine
       return @options[:output_file_path]
     end
 
+    def is_output_ini?()
+      return @options[:output_ini]
+    end
+  
     private
     def download_file(url, filepath)
       Common::Logger::LoggerFactory.get_logger().debug("Downloading from #{url} to #{filepath}")

--- a/src/command_line/provider.rb
+++ b/src/command_line/provider.rb
@@ -76,7 +76,7 @@ module CommandLine
     end
 
     def is_output_ini?()
-      return @options[:output_ini]
+      return @options[:is_output_ini]
     end
   
     private

--- a/src/summary/composer.rb
+++ b/src/summary/composer.rb
@@ -18,7 +18,42 @@ module Summary
       return summary
     end
 
+    def compose_resources(provisioned_resources)
+      output = ""
+      provisioned_resources.each do |provisioned_resource|
+        ip = provisioned_resource.get_ip()
+        unless ip.nil?
+          output += "#{provisioned_resource.get_ip()}"
+          resource = provisioned_resource.get_resource()
+          user_name = get_resource_user_name(resource)
+          unless user_name.nil?
+            output += " ansible_user=#{user_name}"
+          end
+          if resource.respond_to?(:is_windows?)
+            if resource.is_windows?()
+              win_password = provisioned_resource.get_param("win_password")
+              unless win_password.nil?
+                output += " ansible_password=#{win_password}"
+              end
+              output += " ansible_port=5986"
+              output += " ansible_connection=winrm"
+              output += " ansible_winrm_server_cert_validation=ignore"
+            end
+          end
+          output += "\n"
+        end
+      end
+      return output
+    end
+
     private
+
+    def get_resource_user_name(resource)
+      user_name = nil
+      if resource.respond_to?(:get_user_name)
+        user_name = resource.get_user_name()
+      end
+    end
 
     def get_global_summary(global_instrumentors)
       output = "Global Instrumentation:\n\n"

--- a/src/summary/orchestrator.rb
+++ b/src/summary/orchestrator.rb
@@ -31,7 +31,7 @@ module Summary
       if @context.get_command_line_provider().is_output_ini?()
         ini_summary = get_results_ini()
         execution_path = @context.get_app_config_provider.get_execution_path()
-        deployment_name = @context.get_app_config_provider.get_deployment_name()
+        deployment_name = @context.get_command_line_provider.get_deployment_name()
         ini_filename = @context.get_app_config_provider.get_summary_ini_filename()
         ini_file_path = File.absolute_path("#{execution_path}/#{deployment_name}/#{ini_filename}")
         write_summary_file(ini_file_path, ini_summary)

--- a/src/summary/orchestrator.rb
+++ b/src/summary/orchestrator.rb
@@ -30,6 +30,8 @@ module Summary
 
       if @context.get_command_line_provider().is_output_ini?()
         ini_summary = get_results_ini()
+        execution_path = @context.get_app_config_provider.get_execution_path()
+        deployment_name = @context.get_app_config_provider.get_deployment_name()
         ini_filename = @context.get_app_config_provider.get_summary_ini_filename()
         ini_file_path = File.absolute_path("#{execution_path}/#{deployment_name}/#{ini_filename}")
         write_summary_file(ini_file_path, ini_summary)

--- a/src/summary/orchestrator.rb
+++ b/src/summary/orchestrator.rb
@@ -28,6 +28,13 @@ module Summary
         write_summary_file(json_file_path, json_summary)
       end
 
+      if @context.get_command_line_provider().is_output_ini?()
+        ini_summary = get_results_ini()
+        ini_filename = @context.get_app_config_provider.get_summary_ini_filename()
+        ini_file_path = File.absolute_path(ini_filename)
+        write_summary_file(ini_file_path, ini_summary)
+      end
+
       return summary
     end
 
@@ -62,6 +69,12 @@ module Summary
       json_composer_results = @json_composer.execute(provisioned_resources, installed_services, resource_instrumentors, service_instrumentors, global_intrumentors)
 
       return json_composer_results
+    end
+
+    def get_results_ini()
+      provisioned_resources = @context.get_provision_provider().get_all()
+      ini_results = @summary_composer.compose_resources(provisioned_resources)
+      return ini_results
     end
 
     def write_console_message(summary)

--- a/src/summary/orchestrator.rb
+++ b/src/summary/orchestrator.rb
@@ -31,7 +31,7 @@ module Summary
       if @context.get_command_line_provider().is_output_ini?()
         ini_summary = get_results_ini()
         ini_filename = @context.get_app_config_provider.get_summary_ini_filename()
-        ini_file_path = File.absolute_path(ini_filename)
+        ini_file_path = File.absolute_path("#{execution_path}/#{deployment_name}/#{ini_filename}")
         write_summary_file(ini_file_path, ini_summary)
       end
 

--- a/tests/app_config/provider_tests.rb
+++ b/tests/app_config/provider_tests.rb
@@ -12,6 +12,7 @@ describe "AppConfig::Provider" do
       "executionPath"=>"path",
       "defaultUserConfigPath"=>"path/config.json",
       "summaryFilename"=>"filename.txt",
+      "summaryIniFilename"=>"hosts.ini",
       "serviceIdMaxLength"=>99,
       "resourceIdMaxLength"=>99,
       "awsEc2SupportedSizes"=>["t2.nino", "t2.micra", "t2.smallz", "t2.mediums"],
@@ -33,6 +34,12 @@ describe "AppConfig::Provider" do
   describe "get_summary_filename" do
     it "should get summary filename if it exists" do
       expect(provider.get_summary_filename()).must_equal("filename.txt")
+    end
+  end
+
+  describe "get_summary_ini_filename" do
+    it "should get summary ini filename if it exists" do
+      expect(provider.get_summary_ini_filename()).must_equal("hosts.ini")
     end
   end
 

--- a/tests/summary/composer_tests.rb
+++ b/tests/summary/composer_tests.rb
@@ -87,6 +87,12 @@ describe "Summary::Composure" do
     summary.must_include("id2 (#{instrumentation_provider})")
   end
 
+  it "should compose hosts ini" do
+    given_provisioned_resource(host_resource)
+    summary = composer.compose_resources(provisioned_resources)
+    summary.must_include("#{host_resource.get_ip()}")
+  end
+
   let(:composer) { Summary::Composer.new() }
 
   it "should verify composer is created with no errors" do


### PR DESCRIPTION
## Summary

Add an option to write a hosts.ini file for each provisioned host resources. This can then be used with ansible-playbook.

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [X] Documentation updated
- [X] Unit tests updated
- [X] Deployer version updated

